### PR TITLE
WAC-38 add a stub "Insights" page

### DIFF
--- a/ckanext/who_afro/assets/css/who-afro.css
+++ b/ckanext/who_afro/assets/css/who-afro.css
@@ -615,19 +615,25 @@ p.small {
     margin-bottom: 0;
 }
 
-.promoted .big-search-form .lens-btn {
+.promoted .big-search-form .lens-btn,
+.promoted .big-search-form .lens-btn:hover,
+.insights .insight-row .search-section .big-search-form .lens-btn,
+.insights .insight-row .search-section .big-search-form .lens-btn:hover {
+    border-color: var(--primary-navy) thin 1px !important;
+    color: var(--primary-navy) !important;
     height:  50px;
     padding-left: 32px;
     padding-right: 32px;
     border-radius: 0 4px 4px 0;
 }
 
-.promoted .big-search-form .lens-btn:hover {
-    border-color: var(--primary-navy) thin 1px !important;
-    color: var(--primary-navy) !important;
+.promoted .big-search-form .fa-search, .insights .insight-row .search-section .big-search-form .fa-search{
+    font-size:  20px;
+    color: #FFFFFF;
+    margin-right: 2px;
 }
 
-.promoted .big-search-form .lens-btn span.search-label {
+.promoted .big-search-form .lens-btn span.search-label, .insights .insight-row .search-section .big-search-form .lens-btn span.search-label{
     font-weight: 700;
     font-size: 16px;
     line-height: 24px;
@@ -649,7 +655,7 @@ p.small {
                     1px 1px 1px rgba(0, 32, 92, 1);
 }
 
-.promoted .big-search-form input{
+.promoted .big-search-form input, .insights .insight-row .search-section .big-search-form input{
     height:  50px;
     border-color: #FFF;
 }
@@ -659,11 +665,11 @@ p.small {
     margin-bottom: 0;
 }
 
-.promoted .search-section {
+.promoted .search-section, .insights .insight-row .search-section {
     margin-top:28px;
 }
 
-.promoted-right h2:first-child, .promoted .search-section p:first-child {
+.promoted-right h2:first-child, .promoted .search-section p:first-child, .insights .insight-row .search-section p:first-child {
     color: var(--primary-navy);
     font-size: 18px;
     font-weight: 700;
@@ -876,11 +882,7 @@ p.small {
     margin-bottom:  24px;
 }
 
-.insight-square:first-child {
-    margin-right: 24px;
-    width: calc(33.3% - 24px) ;
-}
-.insight-square:nth-child(2) {
+.insight-square {
     margin-right: 24px;
     width: calc(33.3% - 24px) ;
 }

--- a/ckanext/who_afro/blueprints/__init__.py
+++ b/ckanext/who_afro/blueprints/__init__.py
@@ -1,0 +1,5 @@
+import ckanext.who_afro.blueprints.insights as insights
+
+
+def get_blueprints():
+    return [insights.blueprint]

--- a/ckanext/who_afro/blueprints/insights.py
+++ b/ckanext/who_afro/blueprints/insights.py
@@ -1,0 +1,14 @@
+import logging
+
+from flask import Blueprint, render_template
+
+log = logging.getLogger(__name__)
+
+blueprint = Blueprint(
+    "insights", __name__, url_prefix="/insights"
+)
+
+
+@blueprint.get("/", endpoint="index")
+def featured_insights():
+    return render_template("insights/featured.html")

--- a/ckanext/who_afro/plugin.py
+++ b/ckanext/who_afro/plugin.py
@@ -9,6 +9,7 @@ import ckanext.who_afro.actions as who_afro_actions
 import ckanext.who_afro.upload as who_afro_upload
 import ckanext.who_afro.validators as who_afro_validators
 import ckanext.who_afro.helpers as who_afro_helpers
+import ckanext.who_afro.blueprints as who_afro_blueprints
 from ckan.lib.plugins import DefaultPermissionLabels
 
 log = logging.getLogger(__name__)
@@ -23,6 +24,7 @@ class WHOAFROPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
     plugins.implements(plugins.IActions)
     plugins.implements(plugins.IValidators)
     plugins.implements(plugins.IPackageController, inherit=True)
+    plugins.implements(plugins.IBlueprint)
 
     # ITemplateHelpers
     def get_helpers(self):
@@ -124,3 +126,7 @@ class WHOAFROPlugin(plugins.SingletonPlugin, DefaultPermissionLabels):
         data_dict['programme'] = json.loads(data_dict['programme'])
         data_dict['country'] = json.loads(data_dict['country'])
         return data_dict
+
+    def get_blueprint(self):
+        log.info(f"Registering the following blueprints: {who_afro_blueprints.get_blueprints()}")
+        return who_afro_blueprints.get_blueprints()

--- a/ckanext/who_afro/templates/header.html
+++ b/ckanext/who_afro/templates/header.html
@@ -34,14 +34,14 @@
         {{ h.build_nav_main(
             ('home.about', _('About')),
             ('dataset.search', _('Find Data')),
-            ('home.index', _('Insights')),
+            ('insights.index', _('Insights')),
             ('user.edit', _('Manage account'))
              ) }}
     {% else %}
         {{ h.build_nav_main(
             ('home.about', _('About')),
             ('dataset.search', _('Find Data')),
-            ('home.index', _('Insights')),
+            ('insights.index', _('Insights')),
             ('user.login', _('Log in'))
              ) }}
     {% endif %}

--- a/ckanext/who_afro/templates/insights/featured.html
+++ b/ckanext/who_afro/templates/insights/featured.html
@@ -1,6 +1,6 @@
 {% extends "page.html" %}
 
-{% block subtitle %}Featured Insights{% endblock subtitle%}
+{% block subtitle %}{{ _('Featured Insights') }}{% endblock subtitle%}
 
 {% block breadcrumb_content %}
   <li class="active">{% link_for _('Featured Insights'), named_route='insights.index' %}</li>
@@ -14,8 +14,8 @@
                 <div class="promoted promoted-home col-xs-12 col-sm-12 col-lg-12" style="min-height: auto;">
                     <div class="promoted-container row">
                         <div class="promoted-left col-lg-12 col-xs-12 col-sm-12" style="padding-bottom:20px;">
-                            <h1 class="page-title">Insights</h1>
-                            <p>WHO AFRO Health Data Hub insights are a collection of  high quality data analyses, visualisations and reported indicators for us in research and publications.</p>
+                            <h1 class="page-title">{{ _('Insights') }}</h1>
+                            <p>{{ _('WHO AFRO Health Data Hub insights are a collection of  high quality data analyses, visualisations and reported indicators for us in research and publications.') }}</p>
                         </div>
                     </div>
                 </div>
@@ -23,8 +23,8 @@
         </div>
 
         <div class="container" style="padding-top: 50px;">
-            <h2>Featured insight</h1>
-            <p>This month's featured insight is our latest analysis of the 2030 WHO African Region Malaria reporting and the interactions of malaria rates with rainfall.</p>
+            <h2>{{ _('Featured insight') }}</h1>
+            <p>{{ _('This month\'s featured insight is our latest analysis of the 2030 WHO African Region Malaria reporting and the interactions of malaria rates with rainfall.') }}</p>
             <div style="text-align: center;">
                 <iframe title="wmr2030" width="100%" height="480px" src="https://app.powerbi.com/view?r=eyJrIjoiZjYwMDM3YzQtYTg3MC00ZDdiLTg3Y2ItYjU1NmU2NjlhMmZlIiwidCI6IjE3ODczYmFiLTUwOWMtNGM1Zi05MjE2LWI2MjE2MTA5ZjEyNSIsImMiOjl9" frameborder="0" allowFullScreen="true"></iframe>
             </div>
@@ -35,32 +35,32 @@
         <div class="container">
             <div class="row insight-row col-lg-12 col-sm-12 col-xs-12" style="margin-top:50px;">
                 <div class="search-section">
-                    <h2>Search insights</h2>
+                    <h2>{{ _('Search insights') }}</h2>
                     {% snippet 'snippets/search_input.html', placeholder='Search' %}
                 </div>
             </div>
             <div class="row insight-row col-lg-12 col-sm-12 col-xs-12" style="margin-top:50px;">
-                <h2>Other popular insights</h2>
+                <h2>{{ _('Popular insights') }}</h2>
 
                 <div class="insight-square col-lg-4 col-sm-12 col-xs-12">
                     <div class="insight-img-container">
                         <img src="/images/insight_img_1.png" alt="image" style="border: 1px #AAAAAA solid;"/>
                     </div>
-                    <p><a href="#">See insight <span>&rarr;</span></a></p>
+                    <p><a href="#">{{ _('See insight') }} <span>&rarr;</span></a></p>
                 </div>
 
                 <div class="insight-square col-lg-4 col-sm-12 col-xs-12">
                     <div class="insight-img-container">
                         <img src="/images/insight_img_2.png" alt="image" style="border: 1px #AAAAAA solid;"/>
                     </div>
-                    <p><a href="#">See insight <span>&rarr;</span></a></p>
+                    <p><a href="#">{{ _('See insight') }} <span>&rarr;</span></a></p>
                 </div>
 
                 <div class="insight-square col-lg-4 col-sm-12 col-xs-12">
                     <div class="insight-img-container">
                         <img src="/images/insight_img_2.png" alt="image" style="border: 1px #AAAAAA solid;"/>
                     </div>
-                    <p><a href="#">See insight <span>&rarr;</span></a></p>
+                    <p><a href="#">{{ _('See insight') }} <span>&rarr;</span></a></p>
                 </div>
             </div>
         </div>

--- a/ckanext/who_afro/templates/insights/featured.html
+++ b/ckanext/who_afro/templates/insights/featured.html
@@ -1,0 +1,69 @@
+{% extends "page.html" %}
+
+{% block subtitle %}Featured Insights{% endblock subtitle%}
+
+{% block breadcrumb_content %}
+  <li class="active">{% link_for _('Featured Insights'), named_route='insights.index' %}</li>
+{% endblock %}
+
+{% block content %}
+<div role="main">
+    <div class="main hero">
+        <div class="promoted-background">
+            <div class="container">
+                <div class="promoted promoted-home col-xs-12 col-sm-12 col-lg-12" style="min-height: auto;">
+                    <div class="promoted-container row">
+                        <div class="promoted-left col-lg-12 col-xs-12 col-sm-12" style="padding-bottom:20px;">
+                            <h1 class="page-title">Insights</h1>
+                            <p>WHO AFRO Health Data Hub insights are a collection of  high quality data analyses, visualisations and reported indicators for us in research and publications.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="container" style="padding-top: 50px;">
+            <h2>Featured insight</h1>
+            <p>This month's featured insight is our latest analysis of the 2030 WHO African Region Malaria reporting and the interactions of malaria rates with rainfall.</p>
+            <div style="text-align: center;">
+                <iframe title="wmr2030" width="100%" height="480px" src="https://app.powerbi.com/view?r=eyJrIjoiZjYwMDM3YzQtYTg3MC00ZDdiLTg3Y2ItYjU1NmU2NjlhMmZlIiwidCI6IjE3ODczYmFiLTUwOWMtNGM1Zi05MjE2LWI2MjE2MTA5ZjEyNSIsImMiOjl9" frameborder="0" allowFullScreen="true"></iframe>
+            </div>
+        </div>
+    </div>
+
+    <div class="insights">
+        <div class="container">
+            <div class="row insight-row col-lg-12 col-sm-12 col-xs-12" style="margin-top:50px;">
+                <div class="search-section">
+                    <h2>Search insights</h2>
+                    {% snippet 'snippets/search_input.html', placeholder='Search' %}
+                </div>
+            </div>
+            <div class="row insight-row col-lg-12 col-sm-12 col-xs-12" style="margin-top:50px;">
+                <h2>Other popular insights</h2>
+
+                <div class="insight-square col-lg-4 col-sm-12 col-xs-12">
+                    <div class="insight-img-container">
+                        <img src="/images/insight_img_1.png" alt="image" style="border: 1px #AAAAAA solid;"/>
+                    </div>
+                    <p><a href="#">See insight <span>&rarr;</span></a></p>
+                </div>
+
+                <div class="insight-square col-lg-4 col-sm-12 col-xs-12">
+                    <div class="insight-img-container">
+                        <img src="/images/insight_img_2.png" alt="image" style="border: 1px #AAAAAA solid;"/>
+                    </div>
+                    <p><a href="#">See insight <span>&rarr;</span></a></p>
+                </div>
+
+                <div class="insight-square col-lg-4 col-sm-12 col-xs-12">
+                    <div class="insight-img-container">
+                        <img src="/images/insight_img_2.png" alt="image" style="border: 1px #AAAAAA solid;"/>
+                    </div>
+                    <p><a href="#">See insight <span>&rarr;</span></a></p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock content %}


### PR DESCRIPTION
## Description

Adds an Insights page as an example for use at the internal launch demo. Definitely to be replaced in the future.

@cooper667 let's merge this before the final demo deploy please - we can break protocol and force the merge if @jonathansberry doesn't have time to review before you do that deploy.

## Internationalisation and Localisation
Strings are set up for i10n but I haven't actually loaded any translations.

## Checklist

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
