### PR TITLE
WAC-37 replace all UI references to groups with data types

### DIFF
--- a/ckanext/who_afro/assets/css/who-afro.css
+++ b/ckanext/who_afro/assets/css/who-afro.css
@@ -1338,6 +1338,7 @@ a.footer-link:hover,
 
 .add-category{
     margin-bottom: 32px;
+    margin-top: 64px;
 }
 
 

--- a/ckanext/who_afro/templates/group/edit.html
+++ b/ckanext/who_afro/templates/group/edit.html
@@ -1,0 +1,9 @@
+{% ckan_extends %}
+
+{% block breadcrumb_content %}
+  <li>{% link_for _('Data Types'), named_route=group_type+'.index' %}</li>
+  {% block breadcrumb_content_inner %}
+    <li>{% link_for group.display_name|truncate(35), named_route=group_type+'.read', id=group.name, title=group.display_name %}</li>
+    <li class="active">{% link_for _('Manage'), named_route=group_type+'.edit', id=group.name %}</li>
+  {% endblock %}
+{% endblock %}

--- a/ckanext/who_afro/templates/group/index.html
+++ b/ckanext/who_afro/templates/group/index.html
@@ -10,14 +10,14 @@
                 <div class="promoted">
                     <div class="container">
                         <p class="subtitle">Home / </p>
-                        <h1 class="headline">Categories</h1>
+                        <h1 class="headline">Data Types</h1>
                     </div>
                 </div>
             </div>
             <div class="document-categories">
                 <div class="container">
                     {% if h.check_access('group_create') %}
-                        {% link_for _('Add Categories'), named_route=group_type+'.new', class_='btn btn-primary add-category', icon='plus-square' %}
+                        {% link_for _('Add Data Types'), named_route=group_type+'.new', class_='btn btn-primary add-category', icon='plus-square' %}
                     {% endif %}
                     {% block groups_list %}
                       {{ super () }}

--- a/ckanext/who_afro/templates/group/index.html
+++ b/ckanext/who_afro/templates/group/index.html
@@ -1,5 +1,7 @@
 {% ckan_extends %}
 
+{% block subtitle %}{{ h.humanize_entity_type('group', group_type, 'page title') or _('Data Types') }}{% endblock %}
+
 {% block content %}
     <div class="categories layout-{{ homepage_style }}">
         <div id="content" class="container">

--- a/ckanext/who_afro/templates/group/new.html
+++ b/ckanext/who_afro/templates/group/new.html
@@ -1,5 +1,7 @@
 {% ckan_extends %}
 
+{% block subtitle %}{{ h.humanize_entity_type('group', group_type, 'page title') or _('Create a Data Type') }}{% endblock %}
+
 {% block page_heading %}{{ _('Create a Data Type') }}{% endblock %}
 
 {% block breadcrumb_content %}

--- a/ckanext/who_afro/templates/group/new.html
+++ b/ckanext/who_afro/templates/group/new.html
@@ -1,0 +1,14 @@
+{% ckan_extends %}
+
+{% block page_heading %}{{ _('Create a Data Type') }}{% endblock %}
+
+{% block breadcrumb_content %}
+  <li>{{ h.nav_link(
+        _('Data Types'),
+        named_route=group_type+'.index') }}</li>
+  <li class="active">
+    {{ h.nav_link(
+        'Create a Data Type',
+        named_route=group_type~'.new') }}
+  </li>
+{% endblock %}

--- a/ckanext/who_afro/templates/group/new_group_form.html
+++ b/ckanext/who_afro/templates/group/new_group_form.html
@@ -1,0 +1,9 @@
+{% ckan_extends %}
+
+{% block save_text %}
+  {%- if action == "edit" -%}
+    {{ h.humanize_entity_type('group', group_type, 'update label') or _('Update Data Type') }}
+  {%- else -%}
+    {{ h.humanize_entity_type('group', group_type, 'create label') or _('Create Data Type') }}
+  {%- endif -%}
+{% endblock %}

--- a/ckanext/who_afro/templates/group/read_base.html
+++ b/ckanext/who_afro/templates/group/read_base.html
@@ -1,6 +1,6 @@
 {% ckan_extends %}
 
-{% block subtitle %}{{ group_dict.display_name }} {{ g.template_title_delimiter }} {{ _('Category') }}{% endblock %}
+{% block subtitle %}{{ group_dict.display_name }} {{ g.template_title_delimiter }} {{ _('Data Type') }}{% endblock %}
 
 {% block breadcrumb_content %}
   <li>{% link_for _('Data Types'), named_route=group_type+'.index' %}</li>

--- a/ckanext/who_afro/templates/group/read_base.html
+++ b/ckanext/who_afro/templates/group/read_base.html
@@ -3,6 +3,6 @@
 {% block subtitle %}{{ group_dict.display_name }} {{ g.template_title_delimiter }} {{ _('Category') }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li>{% link_for _('Categories'), named_route=group_type+'.index' %}</li>
+  <li>{% link_for _('Data Types'), named_route=group_type+'.index' %}</li>
   <li class="active">{% link_for group_dict.display_name|truncate(35), named_route=group_type+'.read', id=group_dict.name %}</li>
 {% endblock %}

--- a/ckanext/who_afro/templates/group/snippets/group_form.html
+++ b/ckanext/who_afro/templates/group/snippets/group_form.html
@@ -1,0 +1,23 @@
+{% ckan_extends %}
+
+{% block basic_fields %}
+    {% set attrs = {'data-module': 'slug-preview-target', 'class': 'form-control'} %}
+    {{ form.input('title', label=_('Name'), id='field-name', placeholder=h.humanize_entity_type('group', group_type, 'name placeholder') or _('My Data Type'), value=data.title, error=errors.title, classes=['control-full'], attrs=attrs) }}
+
+    {# Perhaps these should be moved into the controller? #}
+    {% set prefix = h.url_for(group_type + '.read', id='') %}
+    {% set domain = h.url_for(group_type + '.read', id='', qualified=true) %}
+    {% set group_type = 'data-type' %}
+    {% set domain = domain|replace("http://", "")|replace("https://", "") %}
+    {% set attrs = {'data-module': 'slug-preview-slug', 'class': 'form-control input-sm', 'data-module-prefix': domain, 'data-module-placeholder': '<' + group_type + '>'} %}
+
+    {{ form.prepend('name', label=_('URL'), prepend=prefix, id='field-url', placeholder=_('my-' + group_type), value=data.name, error=errors.name, attrs=attrs, is_required=true) }}
+
+    {{ form.markdown('description', label=_('Description'), id='field-description', placeholder=h.humanize_entity_type('group', group_type, 'description placeholder') or _('A little information about my group...'), value=data.description, error=errors.description) }}
+
+    {% set is_upload = data.image_url and not data.image_url.startswith('http') %}
+    {% set is_url = data.image_url and data.image_url.startswith('http') %}
+
+    {{ form.image_upload(data, errors, is_upload_enabled=h.uploads_enabled(), is_url=is_url, is_upload=is_upload) }}
+
+  {% endblock %}

--- a/ckanext/who_afro/templates/group/snippets/helper.html
+++ b/ckanext/who_afro/templates/group/snippets/helper.html
@@ -1,0 +1,16 @@
+<div class="module module-narrow module-shallow">
+  <h2 class="module-heading">
+    <i class="fa fa-info-circle"></i>
+    {{ _('What are Data Types?') }}
+  </h2>
+  <div class="module-content">
+    <p>
+      {% trans %}
+        You can use Data Types to create and manage collections of datasets.
+        This could be to catalogue datasets for a particular project or team,
+        or on a particular theme, or as a very simple way to help people find
+        and search your own published datasets.
+      {% endtrans %}
+    </p>
+  </div>
+</div>

--- a/ckanext/who_afro/templates/package/group_list.html
+++ b/ckanext/who_afro/templates/package/group_list.html
@@ -12,7 +12,7 @@
           <option value="{{ option[0] }}"> {{ option[1] }}</option>
         {% endfor %}
       </select>
-      <button type="submit" class="btn btn-primary" title="{{ _('Associate this category with this dataset') }}">{{ _('Add to category') }}</button>
+      <button type="submit" class="btn btn-primary" title="{{ _('Associate this category with this dataset') }}">{{ _('Add to Data Type') }}</button>
     </form>
   {% endif %}
 

--- a/ckanext/who_afro/templates/package/read_base.html
+++ b/ckanext/who_afro/templates/package/read_base.html
@@ -2,6 +2,6 @@
 
 {% block content_primary_nav %}
   {{ h.build_nav_icon(dataset_type ~ '.read', _('Dataset'), id=pkg.id if is_activity_archive else pkg.name, icon='sitemap') }}
-  {{ h.build_nav_icon(dataset_type ~ '.groups', _('Categories'), id=pkg.id if is_activity_archive else pkg.name, icon='users') }}
+  {{ h.build_nav_icon(dataset_type ~ '.groups', _('Data Types'), id=pkg.id if is_activity_archive else pkg.name, icon='cubes') }}
   {{ h.build_nav_icon('activity.package_activity', _('Activity Stream'), id=pkg.id if is_activity_archive else pkg.name, icon='clock') }}
 {% endblock %}

--- a/ckanext/who_afro/templates/snippets/facet_list.html
+++ b/ckanext/who_afro/templates/snippets/facet_list.html
@@ -1,5 +1,16 @@
 {% ckan_extends %}
 
+{% block facet_list_heading %}
+<h2 class="module-heading">
+    <i class="fa fa-filter"></i>
+    {% if 'groups' in title|lower %}
+        Data Types
+    {% else %}
+        {{ title }}
+    {% endif %}
+</h2>
+{% endblock %}
+
 {% block facet_list_items %}
     {% with items = items or h.get_facet_items_dict(name, search_facets) %}
         {% if items %}

--- a/ckanext/who_afro/templates/snippets/search_form.html
+++ b/ckanext/who_afro/templates/snippets/search_form.html
@@ -1,0 +1,29 @@
+{% ckan_extends %}
+
+  {% block search_facets %}
+    {% if facets %}
+      <p class="filter-list">
+        {% for field in facets.fields %}
+          {% set search_facets_items = facets.search.get(field)['items'] if facets.search and field in facets.search else [] %}
+          <span class="facet">
+          {% if 'groups' in facets.titles.get(field)|lower %}
+              Data Types
+          {% else %}
+              {{ facets.titles.get(field) }}
+          {% endif %}
+          :</span>
+          {% for value in facets.fields[field] %}
+            <span class="filtered pill">
+              {%- if facets.translated_fields and (field,value) in facets.translated_fields -%}
+                {{ facets.translated_fields[(field,value)] }}
+              {%- else -%}
+                {{ h.list_dict_filter(search_facets_items, 'name', 'display_name', value) }}
+              {%- endif %}
+              <a href="{{ facets.remove_field(field, value) }}" class="remove" title="{{ _('Remove') }}"><i class="fa fa-times"></i></a>
+            </span>
+          {% endfor %}
+        {% endfor %}
+      </p>
+      <a class="show-filters btn btn-default">{{ _('Filter Results') }}</a>
+    {% endif %}
+  {% endblock %}

--- a/ckanext/who_afro/templates/user/dashboard.html
+++ b/ckanext/who_afro/templates/user/dashboard.html
@@ -4,7 +4,7 @@
     <ul class="nav nav-tabs">
             {{ h.build_nav_icon('dashboard.datasets', h.humanize_entity_type('package', dataset_type, 'my label') or _('My Datasets'), icon='sitemap') }}
             {{ h.build_nav_icon('dashboard.organizations', h.humanize_entity_type('organization', org_type, 'my label') or _('My Organizations'), icon='building-o') }}
-            {{ h.build_nav_icon('dashboard.groups', h.humanize_entity_type('group', group_type, 'my label') or _('My Groups'), icon='users') }}
+            {{ h.build_nav_icon('dashboard.groups', h.humanize_entity_type('group', group_type, 'my label') or _('My Data Types'), icon='cubes') }}
     </ul>
  {% endblock %}
 

--- a/ckanext/who_afro/templates/user/dashboard_groups.html
+++ b/ckanext/who_afro/templates/user/dashboard_groups.html
@@ -4,7 +4,7 @@
 
 {% block page_primary_action %}
   {% if h.check_access('group_create') %}
-    {% link_for _('Add Category'), controller='group', action='new', class_="btn btn-primary", icon="plus-square" %}
+    {% link_for _('Add Data Type'), controller='group', action='new', class_="btn btn-primary", icon="plus-square" %}
   {% endif %}
 {% endblock %}
 
@@ -17,7 +17,7 @@
     </div>
   {% else %}
     <p class="empty">
-      {{ _('You are not a member of any categories.') }}
+      {{ _('You are not a member of any Data Types.') }}
       {% if h.check_access('group_create') %}
         {% link_for _('Create one now?'), controller='group', action='new' %}
       {% endif %}


### PR DESCRIPTION
## Description

- Update in ckan/dashboard 
![image](https://github.com/fjelltopp/ckanext-who-afro/assets/15812707/f7a61388-845a-444b-89de-70e97a41efa9)

- Update in ckan/group
![image](https://github.com/fjelltopp/ckanext-who-afro/assets/15812707/3d8d5fad-551d-4183-b84c-1ddaa7dec923)

- Update in ckan/group/new
![image](https://github.com/fjelltopp/ckanext-who-afro/assets/15812707/7862cfad-79f6-449f-9409-ff4f163f6fca)

- Update in ckan/group/<group_name>
![image](https://github.com/fjelltopp/ckanext-who-afro/assets/15812707/4fcb5c58-d8a8-4f48-93bf-eba8d8182493)

- Update in ckan/group/edit/<group-name>
![image](https://github.com/fjelltopp/ckanext-who-afro/assets/15812707/ad4b622e-c430-41c8-ac58-911d41f4e8b0)

- Update in titles
![image](https://github.com/fjelltopp/ckanext-who-afro/assets/15812707/e7124507-3c72-4a61-afb8-18fa9312d4f2)

- Update in left of ckan/dataset
![image](https://github.com/fjelltopp/ckanext-who-afro/assets/15812707/619a6e1c-a59a-4965-8811-07b0051ff8f3)
![image](https://github.com/fjelltopp/ckanext-who-afro/assets/15812707/b51f1150-e786-4812-a480-8d83b9b31c9a)
![image](https://github.com/fjelltopp/ckanext-who-afro/assets/15812707/f29290f0-a683-496a-86b1-e830ec63b11c)


- Also in ckan/group, added margin to 'Add Data Type' button

**Note: When creating a new 'Data Type', it doesn't seem to appear in the ckan/dataset left panel? May be this is the current behavior? Also adding a dataset to a 'Data Type' seems to work but when browsing to ckan/group/<data-type>, we get a NO DATASETS FOUND**


## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
