### PR TITLE
WAC-42: Check type before loading to dict.

### DIFF
--- a/ckanext/who_afro/plugin.py
+++ b/ckanext/who_afro/plugin.py
@@ -141,9 +141,7 @@ class WHOAFROPlugin(plugins.SingletonPlugin, DefaultTranslation):
         return data_dict
 
     def get_blueprint(self):
-        log.info(
-            f'Registering the following blueprints: {who_afro_blueprints.get_blueprints()}'
-        )
+        log.info(f"Registering the following blueprints: {who_afro_blueprints.get_blueprints()}")
         return who_afro_blueprints.get_blueprints()
 
     # ITranslation

--- a/ckanext/who_afro/plugin.py
+++ b/ckanext/who_afro/plugin.py
@@ -43,14 +43,14 @@ class WHOAFROPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'get_recently_updated_datasets': who_afro_helpers.get_recently_updated_datasets,
             'get_last_modifier': who_afro_helpers.get_last_modifier,
             'format_locale': who_afro_helpers.format_locale,
-            'get_datahub_stats': who_afro_helpers.get_datahub_stats,
+            'get_datahub_stats': who_afro_helpers.get_datahub_stats
         }
 
     # IConfigurer
     def update_config(self, config_):
-        toolkit.add_template_directory(config_, 'templates')
-        toolkit.add_public_directory(config_, 'public')
-        toolkit.add_resource('assets', 'who-afro')
+        toolkit.add_template_directory(config_, "templates")
+        toolkit.add_public_directory(config_, "public")
+        toolkit.add_resource("assets", "who-afro")
 
     # IFacets
     def dataset_facets(self, facet_dict, package_type):
@@ -106,7 +106,7 @@ class WHOAFROPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'autogenerate_name_from_title': who_afro_validators.autogenerate_name_from_title,
             'autofill': who_afro_validators.autofill,
             'autogenerate': who_afro_validators.autogenerate,
-            'isomonth': who_afro_validators.isomonth,
+            'isomonth': who_afro_validators.isomonth
         }
 
     # IPackageContoller
@@ -115,15 +115,15 @@ class WHOAFROPlugin(plugins.SingletonPlugin, DefaultTranslation):
         if package_data.get('private'):
             package_data['state'] = 'deleted'
             context['package'].state = 'deleted'
-            who_afro_upload.add_activity(context, package_data, 'changed')
+            who_afro_upload.add_activity(context, package_data, "changed")
 
     def after_dataset_update(self, context, data_dict):
         if data_dict.get('private'):
-            who_afro_upload.add_activity(context, data_dict, 'changed')
+            who_afro_upload.add_activity(context, data_dict, "changed")
 
     def after_dataset_create(self, context, data_dict):
         if data_dict.get('private'):
-            who_afro_upload.add_activity(context, data_dict, 'new')
+            who_afro_upload.add_activity(context, data_dict, "new")
 
     def before_dataset_index(self, data_dict: Dict) -> Dict:
         """Load custom multivalued fields as objects before solr indexing.

--- a/ckanext/who_afro/plugin.py
+++ b/ckanext/who_afro/plugin.py
@@ -1,6 +1,7 @@
 import logging
 import json
 from collections import OrderedDict
+from typing import Dict
 import ckanext.blob_storage.helpers as blobstorage_helpers
 import ckan.lib.uploader as uploader
 import ckan.plugins as plugins
@@ -30,54 +31,54 @@ class WHOAFROPlugin(plugins.SingletonPlugin, DefaultTranslation):
     # ITemplateHelpers
     def get_helpers(self):
         return {
-            "max_resource_size": uploader.get_max_resource_size,
-            "get_dataset_from_id": who_afro_helpers.get_dataset_from_id,
-            "blob_storage_resource_filename": blobstorage_helpers.resource_filename,
-            "get_facet_items_dict": who_afro_helpers.get_facet_items_dict,
-            "get_all_groups": who_afro_helpers.get_all_groups,
-            "get_featured_datasets": who_afro_helpers.get_featured_datasets,
-            "get_user_from_id": who_afro_helpers.get_user_from_id,
-            "get_user_obj": who_afro_helpers.get_user_obj,
-            "month_formatter": who_afro_helpers.month_formatter,
-            "get_recently_updated_datasets": who_afro_helpers.get_recently_updated_datasets,
-            "get_last_modifier": who_afro_helpers.get_last_modifier,
-            "format_locale": who_afro_helpers.format_locale,
-            "get_datahub_stats": who_afro_helpers.get_datahub_stats,
+            'max_resource_size': uploader.get_max_resource_size,
+            'get_dataset_from_id': who_afro_helpers.get_dataset_from_id,
+            'blob_storage_resource_filename': blobstorage_helpers.resource_filename,
+            'get_facet_items_dict': who_afro_helpers.get_facet_items_dict,
+            'get_all_groups': who_afro_helpers.get_all_groups,
+            'get_featured_datasets': who_afro_helpers.get_featured_datasets,
+            'get_user_from_id': who_afro_helpers.get_user_from_id,
+            'get_user_obj': who_afro_helpers.get_user_obj,
+            'month_formatter': who_afro_helpers.month_formatter,
+            'get_recently_updated_datasets': who_afro_helpers.get_recently_updated_datasets,
+            'get_last_modifier': who_afro_helpers.get_last_modifier,
+            'format_locale': who_afro_helpers.format_locale,
+            'get_datahub_stats': who_afro_helpers.get_datahub_stats,
         }
 
     # IConfigurer
     def update_config(self, config_):
-        toolkit.add_template_directory(config_, "templates")
-        toolkit.add_public_directory(config_, "public")
-        toolkit.add_resource("assets", "who-afro")
+        toolkit.add_template_directory(config_, 'templates')
+        toolkit.add_public_directory(config_, 'public')
+        toolkit.add_resource('assets', 'who-afro')
 
     # IFacets
     def dataset_facets(self, facet_dict, package_type):
         new_facet_dict = OrderedDict()
-        new_facet_dict["groups"] = facet_dict["groups"]
-        new_facet_dict["programme"] = plugins.toolkit._("Programmes")
-        new_facet_dict["country"] = plugins.toolkit._("Countries")
-        new_facet_dict["tags"] = plugins.toolkit._("Keywords")
-        new_facet_dict["res_format"] = plugins.toolkit._("Formats")
-        new_facet_dict["organization"] = facet_dict["organization"]
+        new_facet_dict['groups'] = facet_dict['groups']
+        new_facet_dict['programme'] = plugins.toolkit._('Programmes')
+        new_facet_dict['country'] = plugins.toolkit._('Countries')
+        new_facet_dict['tags'] = plugins.toolkit._('Keywords')
+        new_facet_dict['res_format'] = plugins.toolkit._('Formats')
+        new_facet_dict['organization'] = facet_dict['organization']
         return new_facet_dict
 
     def group_facets(self, facet_dict, group_type, package_type):
         new_facet_dict = OrderedDict()
-        new_facet_dict["programme"] = plugins.toolkit._("Programmes")
-        new_facet_dict["country"] = plugins.toolkit._("Countries")
-        new_facet_dict["tags"] = plugins.toolkit._("Keywords")
-        new_facet_dict["res_format"] = plugins.toolkit._("Formats")
-        new_facet_dict["organization"] = facet_dict["organization"]
+        new_facet_dict['programme'] = plugins.toolkit._('Programmes')
+        new_facet_dict['country'] = plugins.toolkit._('Countries')
+        new_facet_dict['tags'] = plugins.toolkit._('Keywords')
+        new_facet_dict['res_format'] = plugins.toolkit._('Formats')
+        new_facet_dict['organization'] = facet_dict['organization']
         return new_facet_dict
 
     def organization_facets(self, facet_dict, organization_type, package_type):
         new_facet_dict = OrderedDict()
-        new_facet_dict["groups"] = facet_dict["groups"]
-        new_facet_dict["programme"] = plugins.toolkit._("Programmes")
-        new_facet_dict["country"] = plugins.toolkit._("Countries")
-        new_facet_dict["tags"] = plugins.toolkit._("Keywords")
-        new_facet_dict["res_format"] = plugins.toolkit._("Formats")
+        new_facet_dict['groups'] = facet_dict['groups']
+        new_facet_dict['programme'] = plugins.toolkit._('Programmes')
+        new_facet_dict['country'] = plugins.toolkit._('Countries')
+        new_facet_dict['tags'] = plugins.toolkit._('Keywords')
+        new_facet_dict['res_format'] = plugins.toolkit._('Formats')
         return new_facet_dict
 
     # IResourceController
@@ -92,51 +93,59 @@ class WHOAFROPlugin(plugins.SingletonPlugin, DefaultTranslation):
     # IActions
     def get_actions(self):
         return {
-            "user_list": who_afro_actions.user_list,
-            "dataset_duplicate": who_afro_actions.dataset_duplicate,
-            "package_create": who_afro_actions.package_create,
-            "dataset_tag_replace": who_afro_actions.dataset_tag_replace,
-            "user_show_me": who_afro_actions.user_show_me,
+            'user_list': who_afro_actions.user_list,
+            'dataset_duplicate': who_afro_actions.dataset_duplicate,
+            'package_create': who_afro_actions.package_create,
+            'dataset_tag_replace': who_afro_actions.dataset_tag_replace,
+            'user_show_me': who_afro_actions.user_show_me,
         }
 
     # IValidators
     def get_validators(self):
         return {
-            "autogenerate_name_from_title": who_afro_validators.autogenerate_name_from_title,
-            "autofill": who_afro_validators.autofill,
-            "autogenerate": who_afro_validators.autogenerate,
-            "isomonth": who_afro_validators.isomonth,
+            'autogenerate_name_from_title': who_afro_validators.autogenerate_name_from_title,
+            'autofill': who_afro_validators.autofill,
+            'autogenerate': who_afro_validators.autogenerate,
+            'isomonth': who_afro_validators.isomonth,
         }
 
     # IPackageContoller
     def after_dataset_delete(self, context, data_dict):
-        package_data = toolkit.get_action("package_show")(context, data_dict)
-        if package_data.get("private"):
-            package_data["state"] = "deleted"
-            context["package"].state = "deleted"
-            who_afro_upload.add_activity(context, package_data, "changed")
+        package_data = toolkit.get_action('package_show')(context, data_dict)
+        if package_data.get('private'):
+            package_data['state'] = 'deleted'
+            context['package'].state = 'deleted'
+            who_afro_upload.add_activity(context, package_data, 'changed')
 
     def after_dataset_update(self, context, data_dict):
-        if data_dict.get("private"):
-            who_afro_upload.add_activity(context, data_dict, "changed")
+        if data_dict.get('private'):
+            who_afro_upload.add_activity(context, data_dict, 'changed')
 
     def after_dataset_create(self, context, data_dict):
-        if data_dict.get("private"):
-            who_afro_upload.add_activity(context, data_dict, "new")
+        if data_dict.get('private'):
+            who_afro_upload.add_activity(context, data_dict, 'new')
 
-    def before_dataset_index(self, data_dict):
-        if isinstance(data_dict["programme"], str):
-            data_dict["programme"] = json.loads(data_dict["programme"])
-        if isinstance(data_dict["country"], str):
-            data_dict["country"] = json.loads(data_dict["country"])
+    def before_dataset_index(self, data_dict: Dict) -> Dict:
+        """Load custom multivalued fields as objects before solr indexing.
+
+        Args:
+            data_dict (Dict): input data
+
+        Returns:
+            Dict: Normalized input data
+        """
+        if isinstance(data_dict.get('programme'), str):
+            data_dict['programme'] = json.loads(data_dict['programme'])
+        if isinstance(data_dict.get('country'), str):
+            data_dict['country'] = json.loads(data_dict['country'])
         return data_dict
 
     def get_blueprint(self):
         log.info(
-            f"Registering the following blueprints: {who_afro_blueprints.get_blueprints()}"
+            f'Registering the following blueprints: {who_afro_blueprints.get_blueprints()}'
         )
         return who_afro_blueprints.get_blueprints()
 
     # ITranslation
     def i18n_domain(self):
-        return "ckanext-who-afro"
+        return 'ckanext-who-afro'

--- a/ckanext/who_afro/plugin.py
+++ b/ckanext/who_afro/plugin.py
@@ -30,21 +30,6 @@ class WHOAFROPlugin(plugins.SingletonPlugin, DefaultTranslation):
     # ITemplateHelpers
     def get_helpers(self):
         return {
-<<<<<<< Updated upstream
-            'max_resource_size': uploader.get_max_resource_size,
-            'get_dataset_from_id': who_afro_helpers.get_dataset_from_id,
-            'blob_storage_resource_filename': blobstorage_helpers.resource_filename,
-            'get_facet_items_dict': who_afro_helpers.get_facet_items_dict,
-            'get_all_groups': who_afro_helpers.get_all_groups,
-            'get_featured_datasets': who_afro_helpers.get_featured_datasets,
-            'get_user_from_id': who_afro_helpers.get_user_from_id,
-            'get_user_obj': who_afro_helpers.get_user_obj,
-            'month_formatter': who_afro_helpers.month_formatter,
-            'get_recently_updated_datasets': who_afro_helpers.get_recently_updated_datasets,
-            'get_last_modifier': who_afro_helpers.get_last_modifier,
-            'format_locale': who_afro_helpers.format_locale,
-            'get_datahub_stats': who_afro_helpers.get_datahub_stats
-=======
             "max_resource_size": uploader.get_max_resource_size,
             "get_dataset_from_id": who_afro_helpers.get_dataset_from_id,
             "blob_storage_resource_filename": blobstorage_helpers.resource_filename,
@@ -57,7 +42,7 @@ class WHOAFROPlugin(plugins.SingletonPlugin, DefaultTranslation):
             "get_recently_updated_datasets": who_afro_helpers.get_recently_updated_datasets,
             "get_last_modifier": who_afro_helpers.get_last_modifier,
             "format_locale": who_afro_helpers.format_locale,
->>>>>>> Stashed changes
+            "get_datahub_stats": who_afro_helpers.get_datahub_stats,
         }
 
     # IConfigurer
@@ -154,4 +139,4 @@ class WHOAFROPlugin(plugins.SingletonPlugin, DefaultTranslation):
 
     # ITranslation
     def i18n_domain(self):
-        return 'ckanext-who-afro'
+        return "ckanext-who-afro"

--- a/ckanext/who_afro/plugin.py
+++ b/ckanext/who_afro/plugin.py
@@ -30,6 +30,7 @@ class WHOAFROPlugin(plugins.SingletonPlugin, DefaultTranslation):
     # ITemplateHelpers
     def get_helpers(self):
         return {
+<<<<<<< Updated upstream
             'max_resource_size': uploader.get_max_resource_size,
             'get_dataset_from_id': who_afro_helpers.get_dataset_from_id,
             'blob_storage_resource_filename': blobstorage_helpers.resource_filename,
@@ -43,6 +44,20 @@ class WHOAFROPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'get_last_modifier': who_afro_helpers.get_last_modifier,
             'format_locale': who_afro_helpers.format_locale,
             'get_datahub_stats': who_afro_helpers.get_datahub_stats
+=======
+            "max_resource_size": uploader.get_max_resource_size,
+            "get_dataset_from_id": who_afro_helpers.get_dataset_from_id,
+            "blob_storage_resource_filename": blobstorage_helpers.resource_filename,
+            "get_facet_items_dict": who_afro_helpers.get_facet_items_dict,
+            "get_all_groups": who_afro_helpers.get_all_groups,
+            "get_featured_datasets": who_afro_helpers.get_featured_datasets,
+            "get_user_from_id": who_afro_helpers.get_user_from_id,
+            "get_user_obj": who_afro_helpers.get_user_obj,
+            "month_formatter": who_afro_helpers.month_formatter,
+            "get_recently_updated_datasets": who_afro_helpers.get_recently_updated_datasets,
+            "get_last_modifier": who_afro_helpers.get_last_modifier,
+            "format_locale": who_afro_helpers.format_locale,
+>>>>>>> Stashed changes
         }
 
     # IConfigurer
@@ -54,30 +69,30 @@ class WHOAFROPlugin(plugins.SingletonPlugin, DefaultTranslation):
     # IFacets
     def dataset_facets(self, facet_dict, package_type):
         new_facet_dict = OrderedDict()
-        new_facet_dict['groups'] = facet_dict['groups']
-        new_facet_dict['programme'] = plugins.toolkit._('Programmes')
-        new_facet_dict['country'] = plugins.toolkit._('Countries')
-        new_facet_dict['tags'] = plugins.toolkit._('Keywords')
-        new_facet_dict['res_format'] = plugins.toolkit._('Formats')
-        new_facet_dict['organization'] = facet_dict['organization']
+        new_facet_dict["groups"] = facet_dict["groups"]
+        new_facet_dict["programme"] = plugins.toolkit._("Programmes")
+        new_facet_dict["country"] = plugins.toolkit._("Countries")
+        new_facet_dict["tags"] = plugins.toolkit._("Keywords")
+        new_facet_dict["res_format"] = plugins.toolkit._("Formats")
+        new_facet_dict["organization"] = facet_dict["organization"]
         return new_facet_dict
 
     def group_facets(self, facet_dict, group_type, package_type):
         new_facet_dict = OrderedDict()
-        new_facet_dict['programme'] = plugins.toolkit._('Programmes')
-        new_facet_dict['country'] = plugins.toolkit._('Countries')
-        new_facet_dict['tags'] = plugins.toolkit._('Keywords')
-        new_facet_dict['res_format'] = plugins.toolkit._('Formats')
-        new_facet_dict['organization'] = facet_dict['organization']
+        new_facet_dict["programme"] = plugins.toolkit._("Programmes")
+        new_facet_dict["country"] = plugins.toolkit._("Countries")
+        new_facet_dict["tags"] = plugins.toolkit._("Keywords")
+        new_facet_dict["res_format"] = plugins.toolkit._("Formats")
+        new_facet_dict["organization"] = facet_dict["organization"]
         return new_facet_dict
 
     def organization_facets(self, facet_dict, organization_type, package_type):
         new_facet_dict = OrderedDict()
-        new_facet_dict['groups'] = facet_dict['groups']
-        new_facet_dict['programme'] = plugins.toolkit._('Programmes')
-        new_facet_dict['country'] = plugins.toolkit._('Countries')
-        new_facet_dict['tags'] = plugins.toolkit._('Keywords')
-        new_facet_dict['res_format'] = plugins.toolkit._('Formats')
+        new_facet_dict["groups"] = facet_dict["groups"]
+        new_facet_dict["programme"] = plugins.toolkit._("Programmes")
+        new_facet_dict["country"] = plugins.toolkit._("Countries")
+        new_facet_dict["tags"] = plugins.toolkit._("Keywords")
+        new_facet_dict["res_format"] = plugins.toolkit._("Formats")
         return new_facet_dict
 
     # IResourceController
@@ -92,45 +107,49 @@ class WHOAFROPlugin(plugins.SingletonPlugin, DefaultTranslation):
     # IActions
     def get_actions(self):
         return {
-            'user_list': who_afro_actions.user_list,
-            'dataset_duplicate': who_afro_actions.dataset_duplicate,
-            'package_create': who_afro_actions.package_create,
-            'dataset_tag_replace': who_afro_actions.dataset_tag_replace,
-            'user_show_me': who_afro_actions.user_show_me,
+            "user_list": who_afro_actions.user_list,
+            "dataset_duplicate": who_afro_actions.dataset_duplicate,
+            "package_create": who_afro_actions.package_create,
+            "dataset_tag_replace": who_afro_actions.dataset_tag_replace,
+            "user_show_me": who_afro_actions.user_show_me,
         }
 
     # IValidators
     def get_validators(self):
         return {
-            'autogenerate_name_from_title': who_afro_validators.autogenerate_name_from_title,
-            'autofill': who_afro_validators.autofill,
-            'autogenerate': who_afro_validators.autogenerate,
-            'isomonth': who_afro_validators.isomonth
+            "autogenerate_name_from_title": who_afro_validators.autogenerate_name_from_title,
+            "autofill": who_afro_validators.autofill,
+            "autogenerate": who_afro_validators.autogenerate,
+            "isomonth": who_afro_validators.isomonth,
         }
 
     # IPackageContoller
     def after_dataset_delete(self, context, data_dict):
-        package_data = toolkit.get_action('package_show')(context, data_dict)
-        if package_data.get('private'):
-            package_data['state'] = 'deleted'
-            context['package'].state = 'deleted'
+        package_data = toolkit.get_action("package_show")(context, data_dict)
+        if package_data.get("private"):
+            package_data["state"] = "deleted"
+            context["package"].state = "deleted"
             who_afro_upload.add_activity(context, package_data, "changed")
 
     def after_dataset_update(self, context, data_dict):
-        if data_dict.get('private'):
+        if data_dict.get("private"):
             who_afro_upload.add_activity(context, data_dict, "changed")
 
     def after_dataset_create(self, context, data_dict):
-        if data_dict.get('private'):
+        if data_dict.get("private"):
             who_afro_upload.add_activity(context, data_dict, "new")
 
     def before_dataset_index(self, data_dict):
-        data_dict['programme'] = json.loads(data_dict['programme'])
-        data_dict['country'] = json.loads(data_dict['country'])
+        if isinstance(data_dict["programme"], str):
+            data_dict["programme"] = json.loads(data_dict["programme"])
+        if isinstance(data_dict["country"], str):
+            data_dict["country"] = json.loads(data_dict["country"])
         return data_dict
 
     def get_blueprint(self):
-        log.info(f"Registering the following blueprints: {who_afro_blueprints.get_blueprints()}")
+        log.info(
+            f"Registering the following blueprints: {who_afro_blueprints.get_blueprints()}"
+        )
         return who_afro_blueprints.get_blueprints()
 
     # ITranslation

--- a/ckanext/who_afro/tests/test_plugin.py
+++ b/ckanext/who_afro/tests/test_plugin.py
@@ -7,19 +7,21 @@ from ckanext.who_afro.tests import get_context
 
 
 @pytest.mark.usefixtures('clean_db', 'with_plugins')
-class TestPrivateDatasetActivities:
+class TestPrivateDatasetActivities():
 
     def test_activity_is_created_when_creating_private_dataset(self):
         user = factories.User()
         result = call_action(
             'package_create',
             get_context(user['name']),
-            name='updated-name',
+            name="updated-name",
             private=True,
-            owner_org=factories.Organization()['id'],
+            owner_org=factories.Organization()['id']
         )
         activity_stream = call_action(
-            'package_activity_list', get_context(user['name']), id=result['id']
+            'package_activity_list',
+            get_context(user['name']),
+            id=result['id']
         )
         assert len(activity_stream) == 1
 
@@ -34,7 +36,7 @@ class TestPrivateDatasetActivities:
             'package_patch',
             get_context(user['name']),
             id=private_dataset['id'],
-            name='updated-name',
+            name="updated-name"
         )
         activity_stream = call_action(
             'package_activity_list',

--- a/ckanext/who_afro/tests/test_plugin.py
+++ b/ckanext/who_afro/tests/test_plugin.py
@@ -30,7 +30,7 @@ class TestPrivateDatasetActivities():
         private_dataset = factories.Dataset(
             private=True,
             owner_org=factories.Organization()['id'],
-            creator_user_id=user['id'],
+            creator_user_id=user['id']
         )
         call_action(
             'package_patch',
@@ -50,13 +50,17 @@ class TestPrivateDatasetActivities():
         private_dataset = factories.Dataset(
             private=True,
             owner_org=factories.Organization()['id'],
-            creator_user_id=user['id'],
+            creator_user_id=user['id']
         )
         call_action(
-            'package_delete', get_context(user['name']), id=private_dataset['id']
+            'package_delete',
+            get_context(user['name']),
+            id=private_dataset['id']
         )
         activity_stream = call_action(
-            'package_activity_list', get_context(user['name']), id=private_dataset['id']
+            'package_activity_list',
+            get_context(user['name']),
+            id=private_dataset['id']
         )
         assert len(activity_stream) == 1
 

--- a/ckanext/who_afro/tests/test_plugin.py
+++ b/ckanext/who_afro/tests/test_plugin.py
@@ -56,14 +56,18 @@ class TestPrivateDatasetActivities:
         )
         assert len(activity_stream) == 1
 
-    def test_before_dataset_index_loaded_object(self):
-        result = WHOAFROPlugin().before_dataset_index(
-            {"programme": ["foo", "bar"], "country": ["Egipt"]}
+    @pytest.mark.parametrize("input_data, expected_data", [
+        (
+            {"programme": ["foo", "bar"], "country": ["Egypt"]},
+            {"programme": ["foo", "bar"], "country": ["Egypt"]}
+        ),
+        (
+            {"programme": '["foo", "bar"]', "country": '["Egypt"]'},
+            {"programme": ["foo", "bar"], "country": ["Egypt"]}
         )
-        assert result == {"programme": ["foo", "bar"], "country": ["Egipt"]}
-
-    def test_before_dataset_index_string_object(self):
+    ])
+    def test_before_dataset_index(self, input_data, expected_data):
         result = WHOAFROPlugin().before_dataset_index(
-            {"programme": '["foo", "bar"]', "country": '["Egipt"]'}
+            input_data
         )
-        assert result == {"programme": ["foo", "bar"], "country": ["Egipt"]}
+        assert result == expected_data

--- a/ckanext/who_afro/tests/test_plugin.py
+++ b/ckanext/who_afro/tests/test_plugin.py
@@ -6,20 +6,20 @@ from ckanext.who_afro.plugin import WHOAFROPlugin
 from ckanext.who_afro.tests import get_context
 
 
-@pytest.mark.usefixtures("clean_db", "with_plugins")
+@pytest.mark.usefixtures('clean_db', 'with_plugins')
 class TestPrivateDatasetActivities:
 
     def test_activity_is_created_when_creating_private_dataset(self):
         user = factories.User()
         result = call_action(
-            "package_create",
-            get_context(user["name"]),
-            name="updated-name",
+            'package_create',
+            get_context(user['name']),
+            name='updated-name',
             private=True,
-            owner_org=factories.Organization()["id"],
+            owner_org=factories.Organization()['id'],
         )
         activity_stream = call_action(
-            "package_activity_list", get_context(user["name"]), id=result["id"]
+            'package_activity_list', get_context(user['name']), id=result['id']
         )
         assert len(activity_stream) == 1
 
@@ -27,17 +27,19 @@ class TestPrivateDatasetActivities:
         user = factories.User()
         private_dataset = factories.Dataset(
             private=True,
-            owner_org=factories.Organization()["id"],
-            creator_user_id=user["id"],
+            owner_org=factories.Organization()['id'],
+            creator_user_id=user['id'],
         )
         call_action(
-            "package_patch",
-            get_context(user["name"]),
-            id=private_dataset["id"],
-            name="updated-name",
+            'package_patch',
+            get_context(user['name']),
+            id=private_dataset['id'],
+            name='updated-name',
         )
         activity_stream = call_action(
-            "package_activity_list", get_context(user["name"]), id=private_dataset["id"]
+            'package_activity_list',
+            get_context(user['name']),
+            id=private_dataset['id']
         )
         assert len(activity_stream) == 1
 
@@ -45,25 +47,27 @@ class TestPrivateDatasetActivities:
         user = factories.User()
         private_dataset = factories.Dataset(
             private=True,
-            owner_org=factories.Organization()["id"],
-            creator_user_id=user["id"],
+            owner_org=factories.Organization()['id'],
+            creator_user_id=user['id'],
         )
         call_action(
-            "package_delete", get_context(user["name"]), id=private_dataset["id"]
+            'package_delete', get_context(user['name']), id=private_dataset['id']
         )
         activity_stream = call_action(
-            "package_activity_list", get_context(user["name"]), id=private_dataset["id"]
+            'package_activity_list', get_context(user['name']), id=private_dataset['id']
         )
         assert len(activity_stream) == 1
 
-    @pytest.mark.parametrize("input_data, expected_data", [
+
+class TestWHOAFROPlugin:
+    @pytest.mark.parametrize('input_data, expected_data', [
         (
-            {"programme": ["foo", "bar"], "country": ["Egypt"]},
-            {"programme": ["foo", "bar"], "country": ["Egypt"]}
+            {'programme': ['foo', 'bar'], 'country': ['Egypt']},
+            {'programme': ['foo', 'bar'], 'country': ['Egypt']}
         ),
         (
-            {"programme": '["foo", "bar"]', "country": '["Egypt"]'},
-            {"programme": ["foo", "bar"], "country": ["Egypt"]}
+            {'programme': '["foo", "bar"]', 'country': '["Egypt"]'},
+            {'programme': ['foo', 'bar'], 'country': ['Egypt']}
         )
     ])
     def test_before_dataset_index(self, input_data, expected_data):

--- a/ckanext/who_afro/tests/test_plugin.py
+++ b/ckanext/who_afro/tests/test_plugin.py
@@ -2,25 +2,24 @@ import pytest
 
 from ckan.tests import factories
 from ckan.tests.helpers import call_action
+from ckanext.who_afro.plugin import WHOAFROPlugin
 from ckanext.who_afro.tests import get_context
 
 
-@pytest.mark.usefixtures('clean_db', 'with_plugins')
-class TestPrivateDatasetActivities():
+@pytest.mark.usefixtures("clean_db", "with_plugins")
+class TestPrivateDatasetActivities:
 
     def test_activity_is_created_when_creating_private_dataset(self):
         user = factories.User()
         result = call_action(
-            'package_create',
-            get_context(user['name']),
+            "package_create",
+            get_context(user["name"]),
             name="updated-name",
             private=True,
-            owner_org=factories.Organization()['id']
+            owner_org=factories.Organization()["id"],
         )
         activity_stream = call_action(
-            'package_activity_list',
-            get_context(user['name']),
-            id=result['id']
+            "package_activity_list", get_context(user["name"]), id=result["id"]
         )
         assert len(activity_stream) == 1
 
@@ -28,19 +27,17 @@ class TestPrivateDatasetActivities():
         user = factories.User()
         private_dataset = factories.Dataset(
             private=True,
-            owner_org=factories.Organization()['id'],
-            creator_user_id=user['id']
+            owner_org=factories.Organization()["id"],
+            creator_user_id=user["id"],
         )
         call_action(
-            'package_patch',
-            get_context(user['name']),
-            id=private_dataset['id'],
-            name="updated-name"
+            "package_patch",
+            get_context(user["name"]),
+            id=private_dataset["id"],
+            name="updated-name",
         )
         activity_stream = call_action(
-            'package_activity_list',
-            get_context(user['name']),
-            id=private_dataset['id']
+            "package_activity_list", get_context(user["name"]), id=private_dataset["id"]
         )
         assert len(activity_stream) == 1
 
@@ -48,17 +45,25 @@ class TestPrivateDatasetActivities():
         user = factories.User()
         private_dataset = factories.Dataset(
             private=True,
-            owner_org=factories.Organization()['id'],
-            creator_user_id=user['id']
+            owner_org=factories.Organization()["id"],
+            creator_user_id=user["id"],
         )
         call_action(
-            'package_delete',
-            get_context(user['name']),
-            id=private_dataset['id']
+            "package_delete", get_context(user["name"]), id=private_dataset["id"]
         )
         activity_stream = call_action(
-            'package_activity_list',
-            get_context(user['name']),
-            id=private_dataset['id']
+            "package_activity_list", get_context(user["name"]), id=private_dataset["id"]
         )
         assert len(activity_stream) == 1
+
+    def test_before_dataset_index_loaded_object(self):
+        result = WHOAFROPlugin().before_dataset_index(
+            {"programme": ["foo", "bar"], "country": ["Egipt"]}
+        )
+        assert result == {"programme": ["foo", "bar"], "country": ["Egipt"]}
+
+    def test_before_dataset_index_string_object(self):
+        result = WHOAFROPlugin().before_dataset_index(
+            {"programme": '["foo", "bar"]', "country": '["Egipt"]'}
+        )
+        assert result == {"programme": ["foo", "bar"], "country": ["Egipt"]}


### PR DESCRIPTION
## WAC-42: Check type before loading to dict

## Description

When we are loading some of the values we are trying to load the to object with method `json.loads` which takes argument types: string, bytes or buffer, instead of that we are passing already loaded objects. After this PR we will check if variable that we are passing are string.

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [x] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
