### PR TITLE
WAC-65 - Bug in resource read page

### DIFF
--- a/ckanext/who_afro/templates/package/snippets/resources.html
+++ b/ckanext/who_afro/templates/package/snippets/resources.html
@@ -1,0 +1,12 @@
+{% ckan_extends %}
+
+
+{% block resources_list %}
+  <ul class="list-unstyled nav nav-simple">
+    {% for resource in resources %}
+      <li class="nav-item{{ ' active' if active == resource.id }}">
+        <a href="{{ h.url_for("activity.resource_history" if is_activity_archive else '%s_resource.%s' % (pkg.type, (action or 'read')), id=pkg.id if is_activity_archive else pkg.name, resource_id=resource.id, inner_span=true, **({'activity_id': request.view_args.activity_id} if is_activity_archive else {})) }}" title="{{ h.resource_display_name(resource) }}">{{ h.resource_display_name(resource)|truncate(25) }}</a>
+      </li>
+    {% endfor %}
+  </ul>
+{% endblock %}


### PR DESCRIPTION
## Description

Added a template in package/snippets/resources.html that extends from `who-afro-ckan/ckan/ckan/templates/package/snippets/resources.html`, the bug was caused by `who-afro-ckan/ckan/ckanext/activity/templates/package/snippets/resources.html` that extends from the first one as well.

This removes the **<<<<<<< HEAD** that is from `who-afro-ckan/ckan/ckanext/activity/templates/package/snippets/resources.html`

![image](https://github.com/fjelltopp/ckanext-who-afro/assets/15812707/d2886ab5-730d-45a9-9e6f-ad3975034be2)



But could t

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
