### PR TITLE
WAC-30 Metadata changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
       # The CKAN version tag of the Solr and Postgres containers should match
       # the one of the container the tests run on.
       # You can switch this base image with a custom image tailored to your project
-      image: openknowledge/ckan-dev:2.10.0
+      image: ckan/ckan-base:2.10.4
     services:
       solr:
         image: ckan/ckan-solr:2.10-solr8

--- a/ckanext/who_afro/assets/css/who-afro.css
+++ b/ckanext/who_afro/assets/css/who-afro.css
@@ -2006,3 +2006,19 @@ p.learn-more a {
 .groups-container{
     padding: 20px;
 }
+
+.additional-info .scheming-group-title{
+    margin-top: 30px;
+}
+
+.resources h2, .additional-info h2{
+    border-bottom: 1px solid #ddd;
+}
+
+.resources .resource-list{
+    margin-top: 30px;
+}
+
+.page-header .nav-tabs li a{
+    color: var(--primary-navy);
+}

--- a/ckanext/who_afro/assets/css/who-afro.css
+++ b/ckanext/who_afro/assets/css/who-afro.css
@@ -652,6 +652,7 @@ p.small {
     border-radius: 4px;
     outline: none;
     height: auto;
+    appearance: auto;
 }
 
 .form-control:focus {

--- a/ckanext/who_afro/assets/css/who-afro.css
+++ b/ckanext/who_afro/assets/css/who-afro.css
@@ -652,7 +652,14 @@ p.small {
     border-radius: 4px;
     outline: none;
     height: auto;
-    appearance: auto;
+}
+
+select.form-control{
+    background-color: #fff;
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23343a40' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right 0.75rem center;
+    background-size: 16px 12px;
 }
 
 .form-control:focus {

--- a/ckanext/who_afro/helpers.py
+++ b/ckanext/who_afro/helpers.py
@@ -185,3 +185,11 @@ def get_datahub_stats():
             stats['countries'] = len(result['facets']['country'])
 
     return stats
+
+def get_license(license_id):
+    license_list = toolkit.get_action('license_list')({}, {})
+    for license in license_list:
+        if license["id"] == license_id:
+            return license
+    else:
+        return {}

--- a/ckanext/who_afro/licenses.json
+++ b/ckanext/who_afro/licenses.json
@@ -1,0 +1,31 @@
+[
+    {
+        "domain_content": true,
+        "domain_data": true,
+        "domain_software": false,
+        "family": "",
+        "id": "CC-BY-4.0",
+        "maintainer": "Creative Commons",
+        "od_conformance": "approved",
+        "osd_conformance": "not reviewed",
+        "status": "active",
+        "title": "Creative Commons Attribution 4.0",
+        "url": "https://creativecommons.org/licenses/by/4.0/",
+        "license_text": "The World Health Organization (“WHO”) encourages public access and use of the data that it collects and publishes on this regional health data hub web site. The data are organized in datasets and made available in machine-readable format (“Datasets”). The Datasets have been compiled from data provided by WHO’s Member States under the WHO policy on the use and sharing of data collected by WHO in Member States outside the context of public health emergencies.\n\nUse of the data derived from the Datasets, which may appear in formats such as tables and charts, is also subject to these Terms and Conditions. Datasets may include data describing the Dataset called “Metadata”. If any datasets are credited to a source other than WHO, then those materials are not covered by these Terms and Conditions, and permission should be sought from the source provided. You are responsible for determining if this is the case, and if so, you are responsible for obtaining any necessary permission from the sources indicated. The risk of claims resulting from infringement of any third-party-owned component in the materials rests solely with you.\n\nYou may use our application programming interfaces (“APIs”) to facilitate access to the Datasets, whether through a separate web site or through another type of software application. By using the Datasets or any presentations of data derived from them, or by using our APIs in connection with the Datasets, you agree to be bound by these Terms and Conditions, as may be amended from time to time by WHO at its sole discretion.\n\nUnless specifically indicated otherwise, these Datasets are provided to you under a Creative Commons Attribution 4.0 International License (CC BY 4.0), with the additional terms below.  The basic terms applicable to the CC BY 4.0 license may be accessed here. By downloading or using the Datasets, you agree to comply with the terms of the CC BY 4.0 license, as well as the following mandatory and binding addition:\n\nAny dispute relating to the interpretation or application of this license shall, unless amicably settled, be subject to conciliation. In the event of failure of the latter, the dispute shall be settled by arbitration. The arbitration shall be conducted in accordance with the modalities to be agreed upon by the parties or, in the absence of agreement, with the UNCITRAL Arbitration Rules. The parties shall accept the arbitral award as final.",
+        "disclaimer": "WHO reserves the right at any time and from time to time to modify or discontinue, temporarily or permanently, the Datasets, or any means of accessing or utilizing the Datasets with or without prior notice to you.\n\nMaps: The designations employed and the presentation of the material in this publication do not imply the expression of any opinion whatsoever on the part of WHO concerning the legal status of any country, territory, city or area or of its authorities, or concerning the delimitation of its frontiers or boundaries. Dotted and dashed lines on maps represent approximate border lines for which there may not yet be full agreement.\n\nAll references to Kosovo should be understood to be in the context of the United Nations Security Council resolution 1244 (1999).\n\nA dispute exists between the Governments of Argentina and the United Kingdom of Great Britain and Northern Ireland concerning sovereignty over the Falkland Islands (Malvinas).\n\nThe mention of specific companies or of certain manufacturers’ products does not imply that they are endorsed or recommended by WHO in preference to others of a similar nature that are not mentioned. Errors and omissions excepted, the names of proprietary products are distinguished by initial capital letters.\n\nAll reasonable precautions have been taken by WHO to verify the accuracy of the Datasets. However, the Datasets are being provided without warranty of any kind, either expressed or implied. You will be solely responsible for your use of the Datasets. In no event shall WHO be liable for any damages arising from such use. For full disclaimers, terms of use and your indemnification of WHO, please see the site's terms and conditions of use. ",
+        "prohibited_uses": "You shall not attempt to de-anonymise the Datasets or use the Datasets in a manner that falsifies or misrepresents their content.\n\nYou shall not, in connection with your use of the Datasets published on this regional health data hub website, state or imply that WHO endorses, or is affiliated with, you, or that WHO endorses your use of data.who.int, or any content, output, or analysis resulting from or related to the data.who.int, or any entity, organization, company, product or services."
+    }, {
+        "domain_content": false,
+        "domain_data": false,
+        "domain_software": false,
+        "family": "",
+        "id": "who-closed",
+        "is_generic": true,
+        "maintainer": "",
+        "od_conformance": "not reviewed",
+        "osd_conformance": "not reviewed",
+        "status": "active",
+        "title": "WHO Internal Use Only - Not Open Data",
+        "url": ""
+    }
+]

--- a/ckanext/who_afro/plugin.py
+++ b/ckanext/who_afro/plugin.py
@@ -106,7 +106,8 @@ class WHOAFROPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'autogenerate_name_from_title': who_afro_validators.autogenerate_name_from_title,
             'autofill': who_afro_validators.autofill,
             'autogenerate': who_afro_validators.autogenerate,
-            'isomonth': who_afro_validators.isomonth
+            'isomonth': who_afro_validators.isomonth,
+            'language_validator': who_afro_validators.language_validator
         }
 
     # IPackageContoller

--- a/ckanext/who_afro/plugin.py
+++ b/ckanext/who_afro/plugin.py
@@ -43,7 +43,8 @@ class WHOAFROPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'get_recently_updated_datasets': who_afro_helpers.get_recently_updated_datasets,
             'get_last_modifier': who_afro_helpers.get_last_modifier,
             'format_locale': who_afro_helpers.format_locale,
-            'get_datahub_stats': who_afro_helpers.get_datahub_stats
+            'get_datahub_stats': who_afro_helpers.get_datahub_stats,
+            'get_license': who_afro_helpers.get_license
         }
 
     # IConfigurer

--- a/ckanext/who_afro/plugin.py
+++ b/ckanext/who_afro/plugin.py
@@ -107,7 +107,8 @@ class WHOAFROPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'autofill': who_afro_validators.autofill,
             'autogenerate': who_afro_validators.autogenerate,
             'isomonth': who_afro_validators.isomonth,
-            'language_validator': who_afro_validators.language_validator
+            'language_validator': who_afro_validators.language_validator,
+            'who_license_autofill': who_afro_validators.who_license_autofill
         }
 
     # IPackageContoller

--- a/ckanext/who_afro/presets.json
+++ b/ckanext/who_afro/presets.json
@@ -26,7 +26,7 @@
       "values": {
         "form_snippet": "language.html",
         "display_snippet": "language.html",
-        "validators": "language_validator"
+        "validators": "ignore_missing language_validator"
       }
     }, {
       "preset_name": "country",

--- a/ckanext/who_afro/presets.json
+++ b/ckanext/who_afro/presets.json
@@ -110,6 +110,47 @@
           {"value": "onehealth", "label": "OneHealth"}
         ]
       }
+    }, {
+      "preset_name": "sustainable_development_goals",
+      "values": {
+        "form_snippet": "multiple_select.html",
+        "display_snippet": "multiple_inline.html",
+        "validators": "scheming_required scheming_multiple_choice",
+        "output_validators": "scheming_multiple_choice_output",
+        "label": "Programmes",
+        "select_size": "5",
+        "separator": "; ",
+        "choices": [
+          {"value": "1_poverty", "label": "(1) No Poverty"},
+          {"value": "2_hunger", "label": "(2) Zero Hunger"},
+          {"value": "3_health_wellbeing", "label": "(3) Good Health & Wellbeing"},
+          {"value": "4_education", "label": "(4) Quality Education"},
+          {"value": "5_gender_equality", "label": "(5) Gender Equality"},
+          {"value": "6_water_sanitation", "label": "(6) Clean Water & Sanitation"},
+          {"value": "7_vaccine_preventable_diseases", "label": "(7) Vaccine Preventable Diseases"},
+          {"value": "8_work_economy", "label": "(8) Decent Work & Economic Growth"},
+          {"value": "9_industry_innovation_infrastructure", "label": "(9) Industry Innovation & Infrastructure"},
+          {"value": "10_inequality", "label": "(10) Reduced Inequalities"},
+          {"value": "11_sustainable_cities_communities", "label": "(11) Sustainable Cities & Communities"},
+          {"value": "12_responsible_consumption_production", "label": "(10) Responsible Consumption & Production"},
+          {"value": "13_climate", "label": "(13) Climate Action"},
+          {"value": "14_life_below_water", "label": "(14) Life Below water"},
+          {"value": "15_life_on_land", "label": "(15) Life On Land"},
+          {"value": "16_peace_justice", "label": "(16) Peace, Justice & Strong Institutions"},
+          {"value": "17_partnership", "label": "(17) Partnership For The Goals"}
+        ]
+      }
+    }, {
+      "preset_name": "yes_no",
+      "values": {
+        "form_snippet": "select.html",
+        "display_snippet": "select.html",
+        "validators": "scheming_required scheming_choices",
+        "choices": [
+          {"value": "Yes", "label": "Yes"},
+          {"value": "No", "label": "No"}
+        ]
+      }
     }
   ]
 }

--- a/ckanext/who_afro/presets.json
+++ b/ckanext/who_afro/presets.json
@@ -25,10 +25,11 @@
       "preset_name": "country",
       "values": {
         "form_snippet": "multiple_select.html",
-        "display_snippet": "multiple_choice.html",
+        "display_snippet": "multiple_inline.html",
+        "separator": ", ",
         "validators": "scheming_multiple_choice",
         "output_validators": "scheming_multiple_choice_output",
-        "label": "Country",
+        "label": "Countries",
         "choices": [
           {"value": "AO", "label": "Angola"},
           {"value": "BF", "label": "Burkina Faso"},
@@ -76,17 +77,19 @@
           {"value": "UG", "label": "Uganda"},
           {"value": "ZA", "label": "South Africa"},
           {"value": "ZM", "label": "Zambia"},
-          {"value": "ZW", "label": "Zimbabwe"}
+          {"value": "ZW", "label": "Zimbabwe"},
+          {"value": "AFRO", "label": "WHO African Region"}
         ]
       }
     }, {
       "preset_name": "programme",
       "values": {
         "form_snippet": "multiple_select.html",
-        "display_snippet": "multiple_choice.html",
+        "display_snippet": "multiple_inline.html",
         "validators": "scheming_multiple_choice",
         "output_validators": "scheming_multiple_choice_output",
-        "label": "Programme",
+        "label": "Programmes",
+        "separator": "; ",
         "choices": [
           {"value": "hiv", "label": "HIV"},
           {"value": "srh", "label": "SRH"},

--- a/ckanext/who_afro/presets.json
+++ b/ckanext/who_afro/presets.json
@@ -22,6 +22,13 @@
         "validators": "isomonth"
       }
     }, {
+      "preset_name": "language",
+      "values": {
+        "form_snippet": "language.html",
+        "display_snippet": "language.html",
+        "validators": "language_validator"
+      }
+    }, {
       "preset_name": "country",
       "values": {
         "form_snippet": "multiple_select.html",

--- a/ckanext/who_afro/presets.json
+++ b/ckanext/who_afro/presets.json
@@ -26,7 +26,7 @@
       "values": {
         "form_snippet": "language.html",
         "display_snippet": "language.html",
-        "validators": "ignore_missing language_validator"
+        "validators": "scheming_required language_validator"
       }
     }, {
       "preset_name": "country",
@@ -34,10 +34,12 @@
         "form_snippet": "multiple_select.html",
         "display_snippet": "multiple_inline.html",
         "separator": ", ",
-        "validators": "scheming_multiple_choice",
+        "validators": "scheming_required scheming_multiple_choice",
         "output_validators": "scheming_multiple_choice_output",
         "label": "Countries",
+        "select_size": "5",
         "choices": [
+          {"value": "AFRO", "label": "WHO African Region"},
           {"value": "AO", "label": "Angola"},
           {"value": "BF", "label": "Burkina Faso"},
           {"value": "BI", "label": "Burundi"},
@@ -84,8 +86,7 @@
           {"value": "UG", "label": "Uganda"},
           {"value": "ZA", "label": "South Africa"},
           {"value": "ZM", "label": "Zambia"},
-          {"value": "ZW", "label": "Zimbabwe"},
-          {"value": "AFRO", "label": "WHO African Region"}
+          {"value": "ZW", "label": "Zimbabwe"}
         ]
       }
     }, {
@@ -93,9 +94,10 @@
       "values": {
         "form_snippet": "multiple_select.html",
         "display_snippet": "multiple_inline.html",
-        "validators": "scheming_multiple_choice",
+        "validators": "scheming_required scheming_multiple_choice",
         "output_validators": "scheming_multiple_choice_output",
         "label": "Programmes",
+        "select_size": "5",
         "separator": "; ",
         "choices": [
           {"value": "hiv", "label": "HIV"},

--- a/ckanext/who_afro/schemas/dataset.yaml
+++ b/ckanext/who_afro/schemas/dataset.yaml
@@ -15,47 +15,58 @@ dataset_fields:
   field_name: title
   label: Title
   preset: title
+  required: true
   form_placeholder: eg. A descriptive title
 
 - field_name: name
   label: URL
   preset: dataset_slug
+  required: true
   form_placeholder: eg. my-dataset
 
-- field_name: notes
-  label: Description
-  form_snippet: markdown.html
-  form_placeholder: eg. Some useful notes about the data
+- field_name: country
+  required: true
+  preset: country
+
+- field_name: programm
+  required: true
+  preset: programme
 
 - field_name: tag_string
+  required: true
   label: Tags
   preset: tag_string_autocomplete
   form_placeholder: eg. economy, mental health, government
 
 - field_name: maintainer
   label: Maintainer
+  required: true
   user_field: fullname
   form_snippet: user.html
 
 - field_name: maintainer_email
   label: Maintainer Email
+  required: true
   user_field: email
   form_snippet: user.html
   display_snippet: email.html
 
 - field_name: license_id
+  required: true
   label: License
   form_snippet: license.html
   help_text: License definitions and additional information can be found at http://opendefinition.org/
 
 - field_name: owner_org
+  required: true
   label: Organization
   preset: dataset_organization
 
 - field_name: private
   label: Visibility
   help_text: Restrict access
-  help_inline: true
+  help_inline: false
+  required: true
   preset: select
   choices:
   - value: false
@@ -69,15 +80,49 @@ dataset_fields:
     title: About the data
     description: Please provide as many details as possible to facilitate the reuse of the data.
 
-  field_name: programme
-  preset: programme
+  field_name: accrual_periodicity
+  label: Accrual Periodicity
+  form_placeholder: e.g. Annual
+  help_text: Indicate how frequently new data is collected and consolidated into this dataset.
 
-- field_name: country
-  preset: country
+- field_name: provenance
+  label: Provenance
+  form_placeholder: e.g. Country, Territory or Area Reported
+  help_text: Briefly describe where the data comes from.
+
+- field_name: temporal_start
+  label: Temporaral Start Date
+  preset: date
+  help_text: For time series data, this should be the earliest date reported in the data.
+
+- field_name: temporal_end
+  label: Temporaral End Date
+  preset: date
+  help_text: For time series data, this should be the latest data reported in the data. Leave blank if dataset has an indefinte end.
+
+- field_name: temporal_resolution
+  label: Temporaral Resolution
+  form_placeholder: eg. Daily or Every 2 weeks
+  help_text: For time series data, this should be the minimum temporal difference represented in the data.
+
+- field_name: spatial_resolution
+  label: Spatial Resolution
+  form_placeholder: eg. Admin Level 1 (national) or Point Level or 100m2
+  help_text: For spatial data, this should be the minimum spatial difference represented in the data.
 
 - field_name: language
   label: Dataset Language
   preset: language
+
+- field_name: notes
+  label: Description
+  form_snippet: markdown.html
+  form_placeholder: Please give any useful notes about how to navigate and use the data.
+
+- field_name: source
+  label: Source
+  form_snippet: markdown.html
+  form_placeholder: Give specific further details about how the data was sourced.
 
 
 resource_fields:

--- a/ckanext/who_afro/schemas/dataset.yaml
+++ b/ckanext/who_afro/schemas/dataset.yaml
@@ -7,7 +7,12 @@ about_url: http://github.com/ckan/ckanext-scheming
 
 dataset_fields:
 
-- field_name: title
+- start_form_page:
+    title: General Metadata
+    description:
+      These fields provide an overview of the dataset, helping users to search and find relevant data within the catalogue.
+
+  field_name: title
   label: Title
   preset: title
   form_placeholder: eg. A descriptive title
@@ -22,21 +27,10 @@ dataset_fields:
   form_snippet: markdown.html
   form_placeholder: eg. Some useful notes about the data
 
-- field_name: programme
-  preset: programme
-
-- field_name: country
-  preset: country
-
 - field_name: tag_string
   label: Tags
   preset: tag_string_autocomplete
   form_placeholder: eg. economy, mental health, government
-
-- field_name: license_id
-  label: License
-  form_snippet: license.html
-  help_text: License definitions and additional information can be found at http://opendefinition.org/
 
 - field_name: maintainer
   label: Maintainer
@@ -48,6 +42,11 @@ dataset_fields:
   user_field: email
   form_snippet: user.html
   display_snippet: email.html
+
+- field_name: license_id
+  label: License
+  form_snippet: license.html
+  help_text: License definitions and additional information can be found at http://opendefinition.org/
 
 - field_name: owner_org
   label: Organization
@@ -66,11 +65,19 @@ dataset_fields:
   validators: boolean_validator
   output_validators: boolean_validator
 
+- start_form_page:
+    title: About the data
+    description: Please provide as many details as possible to facilitate the reuse of the data.
+
+  field_name: programme
+  preset: programme
+
+- field_name: country
+  preset: country
+
 - field_name: language
   label: Dataset Language
   preset: language
-
-
 
 
 resource_fields:

--- a/ckanext/who_afro/schemas/dataset.yaml
+++ b/ckanext/who_afro/schemas/dataset.yaml
@@ -66,6 +66,12 @@ dataset_fields:
   validators: boolean_validator
   output_validators: boolean_validator
 
+- field_name: language
+  label: Dataset Language
+  preset: language
+
+
+
 
 resource_fields:
 

--- a/ckanext/who_afro/schemas/dataset.yaml
+++ b/ckanext/who_afro/schemas/dataset.yaml
@@ -5,8 +5,6 @@ about: A customized dataset schema for WHO AFRO CKAN deployment
 about_url: http://github.com/ckan/ckanext-scheming
 
 
-dataset_fields:
-
 - start_form_page:
     title: General Metadata
     description:
@@ -17,32 +15,44 @@ dataset_fields:
   preset: title
   required: true
   form_placeholder: eg. A descriptive title
+  display_group: Overview
 
 - field_name: name
   label: URL
   preset: dataset_slug
   required: true
   form_placeholder: eg. my-dataset
+  display_group: Overview
+
+- field_name: notes
+  required: true
+  label: Description
+  form_snippet: markdown.html
+  form_placeholder: Please give a useful introduction to the dataset which will be shown straight after the title.
 
 - field_name: country
   required: true
   preset: country
+  display_group: Overview
 
-- field_name: programm
+- field_name: programme
   required: true
   preset: programme
+  display_group: Overview
 
 - field_name: tag_string
   required: true
   label: Tags
   preset: tag_string_autocomplete
   form_placeholder: eg. economy, mental health, government
+  display_group: Overview
 
 - field_name: maintainer
   label: Maintainer
   required: true
   user_field: fullname
   form_snippet: user.html
+  display_group: Overview
 
 - field_name: maintainer_email
   label: Maintainer Email
@@ -50,21 +60,23 @@ dataset_fields:
   user_field: email
   form_snippet: user.html
   display_snippet: email.html
+  display_group: Overview
 
-- field_name: license_id
+- field_name: language
   required: true
-  label: License
-  form_snippet: license.html
-  help_text: License definitions and additional information can be found at http://opendefinition.org/
+  label: Dataset Language
+  preset: language
+  display_group: Overview
 
 - field_name: owner_org
   required: true
   label: Organization
   preset: dataset_organization
+  display_group: Access & Use
 
 - field_name: private
   label: Visibility
-  help_text: Restrict access
+  help_text: Public data is published under the "CC BY 4.0" license, private data is only visible to designated collaborators and members of the above-specified team.
   help_inline: false
   required: true
   preset: select
@@ -75,54 +87,66 @@ dataset_fields:
     label: Private
   validators: boolean_validator
   output_validators: boolean_validator
+  display_group: Access & Use
+
+- field_name: license_id
+  label: License
+  required: true
+  preset: preset_value
+  validators: who_license_autofill
+  display_group: Access & Use
+
 
 - start_form_page:
     title: About the data
     description: Please provide as many details as possible to facilitate the reuse of the data.
 
   field_name: accrual_periodicity
-  label: Accrual Periodicity
+  label: Frequency of data collection
   form_placeholder: e.g. Annual
-  help_text: Indicate how frequently new data is collected and consolidated into this dataset.
+  help_text: Indicate how frequently new data is incorporated into this dataset.
+  display_group: About the Data
 
 - field_name: provenance
   label: Provenance
-  form_placeholder: e.g. Country, Territory or Area Reported
-  help_text: Briefly describe where the data comes from.
+  form_placeholder: e.g. "Country reports" or "Household surveys"
+  help_text: Briefly describe where the data has come from.
+  display_group: About the Data
 
 - field_name: temporal_start
-  label: Temporaral Start Date
+  label: Temporal Start Date
   preset: date
   help_text: For time series data, this should be the earliest date reported in the data.
+  display_group: About the Data
 
 - field_name: temporal_end
-  label: Temporaral End Date
+  label: Temporal End Date
   preset: date
   help_text: For time series data, this should be the latest data reported in the data. Leave blank if dataset has an indefinte end.
+  display_group: About the Data
 
 - field_name: temporal_resolution
-  label: Temporaral Resolution
+  label: Temporal Resolution
   form_placeholder: eg. Daily or Every 2 weeks
   help_text: For time series data, this should be the minimum temporal difference represented in the data.
+  display_group: About the Data
 
 - field_name: spatial_resolution
   label: Spatial Resolution
   form_placeholder: eg. Admin Level 1 (national) or Point Level or 100m2
   help_text: For spatial data, this should be the minimum spatial difference represented in the data.
-
-- field_name: language
-  label: Dataset Language
-  preset: language
-
-- field_name: notes
-  label: Description
-  form_snippet: markdown.html
-  form_placeholder: Please give any useful notes about how to navigate and use the data.
+  display_group: About the Data
 
 - field_name: source
   label: Source
   form_snippet: markdown.html
   form_placeholder: Give specific further details about how the data was sourced.
+  display_group: About the Data
+
+- field_name: sustainable_development_goals
+  label: Sustainable Development Goals
+  preset: sustainable_development_goals
+  display_group: About the Data
 
 
 resource_fields:

--- a/ckanext/who_afro/schemas/indicator.yaml
+++ b/ckanext/who_afro/schemas/indicator.yaml
@@ -5,6 +5,13 @@ about: A customized dataset schema for WHO AFRO CKAN deployment
 about_url: http://github.com/ckan/ckanext-scheming
 
 
+scheming_version: 2
+dataset_type: dataset
+name: General Data
+about: A customized dataset schema for WHO AFRO CKAN deployment
+about_url: http://github.com/ckan/ckanext-scheming
+
+
 dataset_fields:
 
 - start_form_page:
@@ -15,47 +22,58 @@ dataset_fields:
   field_name: title
   label: Title
   preset: title
+  required: true
   form_placeholder: eg. A descriptive title
 
 - field_name: name
   label: URL
   preset: dataset_slug
+  required: true
   form_placeholder: eg. my-dataset
 
-- field_name: notes
-  label: Description
-  form_snippet: markdown.html
-  form_placeholder: eg. Some useful notes about the data
+- field_name: country
+  required: true
+  preset: country
+
+- field_name: programm
+  required: true
+  preset: programme
 
 - field_name: tag_string
+  required: true
   label: Tags
   preset: tag_string_autocomplete
   form_placeholder: eg. economy, mental health, government
 
 - field_name: maintainer
   label: Maintainer
+  required: true
   user_field: fullname
   form_snippet: user.html
 
 - field_name: maintainer_email
   label: Maintainer Email
+  required: true
   user_field: email
   form_snippet: user.html
   display_snippet: email.html
 
 - field_name: license_id
+  required: true
   label: License
   form_snippet: license.html
   help_text: License definitions and additional information can be found at http://opendefinition.org/
 
 - field_name: owner_org
+  required: true
   label: Organization
   preset: dataset_organization
 
 - field_name: private
   label: Visibility
   help_text: Restrict access
-  help_inline: true
+  help_inline: false
+  required: true
   preset: select
   choices:
   - value: false
@@ -69,15 +87,49 @@ dataset_fields:
     title: About the data
     description: Please provide as many details as possible to facilitate the reuse of the data.
 
-  field_name: programme
-  preset: programme
+  field_name: accrual_periodicity
+  label: Accrual Periodicity
+  form_placeholder: e.g. Annual
+  help_text: Indicate how frequently new data is collected and consolidated into this dataset.
 
-- field_name: country
-  preset: country
+- field_name: provenance
+  label: Provenance
+  form_placeholder: e.g. Country, Territory or Area Reported
+  help_text: Briefly describe where the data comes from.
+
+- field_name: temporal_start
+  label: Temporaral Start Date
+  preset: date
+  help_text: For time series data, this should be the earliest date reported in the data.
+
+- field_name: temporal_end
+  label: Temporaral End Date
+  preset: date
+  help_text: For time series data, this should be the latest data reported in the data. Leave blank if dataset has an indefinte end.
+
+- field_name: temporal_resolution
+  label: Temporaral Resolution
+  form_placeholder: eg. Daily or Every 2 weeks
+  help_text: For time series data, this should be the minimum temporal difference represented in the data.
+
+- field_name: spatial_resolution
+  label: Spatial Resolution
+  form_placeholder: eg. Admin Level 1 (national) or Point Level or 100m2
+  help_text: For spatial data, this should be the minimum spatial difference represented in the data.
 
 - field_name: language
   label: Dataset Language
   preset: language
+
+- field_name: notes
+  label: Description
+  form_snippet: markdown.html
+  form_placeholder: Please give any useful notes about how to navigate and use the data.
+
+- field_name: source
+  label: Source
+  form_snippet: markdown.html
+  form_placeholder: Give specific further details about how the data was sourced.
 
 
 resource_fields:
@@ -94,3 +146,4 @@ resource_fields:
 - field_name: format
   label: Format
   preset: resource_format_autocomplete
+

--- a/ckanext/who_afro/schemas/indicator.yaml
+++ b/ckanext/who_afro/schemas/indicator.yaml
@@ -66,6 +66,9 @@ dataset_fields:
   validators: boolean_validator
   output_validators: boolean_validator
 
+- field_name: language
+  label: Dataset Language
+  preset: language
 
 resource_fields:
 

--- a/ckanext/who_afro/schemas/indicator.yaml
+++ b/ckanext/who_afro/schemas/indicator.yaml
@@ -25,12 +25,17 @@ dataset_fields:
   form_placeholder: eg. my-dataset
   display_group: Overview
 
+- field_name: notes
+  label: Description
+  form_snippet: markdown.html
+  form_placeholder: Please give a useful introduction to the dataset which will be shown straight after the title.
+
 - field_name: country
   required: true
   preset: country
   display_group: Overview
 
-- field_name: programm
+- field_name: programme
   required: true
   preset: programme
   display_group: Overview
@@ -41,11 +46,6 @@ dataset_fields:
   preset: tag_string_autocomplete
   form_placeholder: eg. economy, mental health, government
   display_group: Overview
-
-- field_name: notes
-  label: Description
-  form_snippet: markdown.html
-  form_placeholder: Please give any useful notes about how to navigate and use the data.
 
 - field_name: maintainer
   label: Maintainer
@@ -192,6 +192,11 @@ dataset_fields:
   form_placeholder: e.g. Negativity
   display_group: Indicator Details
 
+- field_name: preferred_semantic_value_type
+  label: Preferred Semantic Value Type
+  form_placeholder: e.g. Rate per 1000
+  display_group: Indicator Details
+
 - field_name: confidence_intervals
   label: Confidence Intervals
   preset: yes_no
@@ -208,6 +213,35 @@ dataset_fields:
   form_placeholder: e.g. Incomplete
   display_group: Indicator Details
 
+- field_name: method_of_measurement
+  form_snippet: markdown.html
+  label: Method of Measurement
+  form_placeholder: Please give details of how this indicator is measured.
+  display_group: Methodology
+
+- field_name: method_of_estimation_aggregates
+  label: Method of Estimation Aggregates
+  form_snippet: markdown.html
+  form_placeholder: Please share details about how sources were aggregated.
+  display_group: Methodology
+
+- field_name: process_of_validation
+  label: Process of Validation
+  form_snippet: markdown.html
+  form_placeholder: Please give details of how this indicator is validated
+  display_group: Methodology
+
+- field_name: rationale
+  label: Rationale
+  form_snippet: markdown.html
+  form_placeholder: Please share the rationale behind tracking this indicator.
+  display_group: Methodology
+
+- field_name: comments
+  label: Comments
+  form_snippet: markdown.html
+  form_placeholder: Please share any further relevant comments on the data
+  display_group: Methodology
 
 resource_fields:
 

--- a/ckanext/who_afro/schemas/indicator.yaml
+++ b/ckanext/who_afro/schemas/indicator.yaml
@@ -26,6 +26,7 @@ dataset_fields:
   display_group: Overview
 
 - field_name: notes
+  required: true
   label: Description
   form_snippet: markdown.html
   form_placeholder: Please give a useful introduction to the dataset which will be shown straight after the title.
@@ -62,14 +63,8 @@ dataset_fields:
   display_snippet: email.html
   display_group: Overview
 
-- field_name: license_id
-  required: true
-  label: License
-  form_snippet: license.html
-  help_text: License definitions and additional information can be found at http://opendefinition.org/
-  display_group: Access & Use
-
 - field_name: language
+  required: true
   label: Dataset Language
   preset: language
   display_group: Overview
@@ -82,7 +77,7 @@ dataset_fields:
 
 - field_name: private
   label: Visibility
-  help_text: Restrict access
+  help_text: Public data is published under the "CC BY 4.0" license, private data is only visible to designated collaborators and members of the above-specified team.
   help_inline: false
   required: true
   preset: select
@@ -95,36 +90,44 @@ dataset_fields:
   output_validators: boolean_validator
   display_group: Access & Use
 
+- field_name: license_id
+  label: License
+  required: true
+  preset: preset_value
+  validators: who_license_autofill
+  display_group: Access & Use
+
+
 - start_form_page:
     title: About the data
     description: Please provide as many details as possible to facilitate the reuse of the data.
 
   field_name: accrual_periodicity
-  label: Accrual Periodicity
+  label: Frequency of data collection
   form_placeholder: e.g. Annual
-  help_text: Indicate how frequently new data is collected and consolidated into this dataset.
+  help_text: Indicate how frequently new data is incorporated into this dataset.
   display_group: About the Data
 
 - field_name: provenance
   label: Provenance
-  form_placeholder: e.g. Country, Territory or Area Reported
-  help_text: Briefly describe where the data comes from.
+  form_placeholder: e.g. "Country reports" or "Household surveys"
+  help_text: Briefly describe where the data has come from.
   display_group: About the Data
 
 - field_name: temporal_start
-  label: Temporaral Start Date
+  label: Temporal Start Date
   preset: date
   help_text: For time series data, this should be the earliest date reported in the data.
   display_group: About the Data
 
 - field_name: temporal_end
-  label: Temporaral End Date
+  label: Temporal End Date
   preset: date
   help_text: For time series data, this should be the latest data reported in the data. Leave blank if dataset has an indefinte end.
   display_group: About the Data
 
 - field_name: temporal_resolution
-  label: Temporaral Resolution
+  label: Temporal Resolution
   form_placeholder: eg. Daily or Every 2 weeks
   help_text: For time series data, this should be the minimum temporal difference represented in the data.
   display_group: About the Data
@@ -242,6 +245,7 @@ dataset_fields:
   form_snippet: markdown.html
   form_placeholder: Please share any further relevant comments on the data
   display_group: Methodology
+
 
 resource_fields:
 

--- a/ckanext/who_afro/schemas/indicator.yaml
+++ b/ckanext/who_afro/schemas/indicator.yaml
@@ -4,14 +4,6 @@ name: Indicator
 about: A customized dataset schema for WHO AFRO CKAN deployment
 about_url: http://github.com/ckan/ckanext-scheming
 
-
-scheming_version: 2
-dataset_type: dataset
-name: General Data
-about: A customized dataset schema for WHO AFRO CKAN deployment
-about_url: http://github.com/ckan/ckanext-scheming
-
-
 dataset_fields:
 
 - start_form_page:
@@ -24,32 +16,43 @@ dataset_fields:
   preset: title
   required: true
   form_placeholder: eg. A descriptive title
+  display_group: Overview
 
 - field_name: name
   label: URL
   preset: dataset_slug
   required: true
   form_placeholder: eg. my-dataset
+  display_group: Overview
 
 - field_name: country
   required: true
   preset: country
+  display_group: Overview
 
 - field_name: programm
   required: true
   preset: programme
+  display_group: Overview
 
 - field_name: tag_string
   required: true
   label: Tags
   preset: tag_string_autocomplete
   form_placeholder: eg. economy, mental health, government
+  display_group: Overview
+
+- field_name: notes
+  label: Description
+  form_snippet: markdown.html
+  form_placeholder: Please give any useful notes about how to navigate and use the data.
 
 - field_name: maintainer
   label: Maintainer
   required: true
   user_field: fullname
   form_snippet: user.html
+  display_group: Overview
 
 - field_name: maintainer_email
   label: Maintainer Email
@@ -57,17 +60,25 @@ dataset_fields:
   user_field: email
   form_snippet: user.html
   display_snippet: email.html
+  display_group: Overview
 
 - field_name: license_id
   required: true
   label: License
   form_snippet: license.html
   help_text: License definitions and additional information can be found at http://opendefinition.org/
+  display_group: Access & Use
+
+- field_name: language
+  label: Dataset Language
+  preset: language
+  display_group: Overview
 
 - field_name: owner_org
   required: true
   label: Organization
   preset: dataset_organization
+  display_group: Access & Use
 
 - field_name: private
   label: Visibility
@@ -82,6 +93,7 @@ dataset_fields:
     label: Private
   validators: boolean_validator
   output_validators: boolean_validator
+  display_group: Access & Use
 
 - start_form_page:
     title: About the data
@@ -91,45 +103,110 @@ dataset_fields:
   label: Accrual Periodicity
   form_placeholder: e.g. Annual
   help_text: Indicate how frequently new data is collected and consolidated into this dataset.
+  display_group: About the Data
 
 - field_name: provenance
   label: Provenance
   form_placeholder: e.g. Country, Territory or Area Reported
   help_text: Briefly describe where the data comes from.
+  display_group: About the Data
 
 - field_name: temporal_start
   label: Temporaral Start Date
   preset: date
   help_text: For time series data, this should be the earliest date reported in the data.
+  display_group: About the Data
 
 - field_name: temporal_end
   label: Temporaral End Date
   preset: date
   help_text: For time series data, this should be the latest data reported in the data. Leave blank if dataset has an indefinte end.
+  display_group: About the Data
 
 - field_name: temporal_resolution
   label: Temporaral Resolution
   form_placeholder: eg. Daily or Every 2 weeks
   help_text: For time series data, this should be the minimum temporal difference represented in the data.
+  display_group: About the Data
 
 - field_name: spatial_resolution
   label: Spatial Resolution
   form_placeholder: eg. Admin Level 1 (national) or Point Level or 100m2
   help_text: For spatial data, this should be the minimum spatial difference represented in the data.
-
-- field_name: language
-  label: Dataset Language
-  preset: language
-
-- field_name: notes
-  label: Description
-  form_snippet: markdown.html
-  form_placeholder: Please give any useful notes about how to navigate and use the data.
+  display_group: About the Data
 
 - field_name: source
   label: Source
   form_snippet: markdown.html
   form_placeholder: Give specific further details about how the data was sourced.
+  display_group: About the Data
+
+- field_name: sustainable_development_goals
+  label: Sustainable Development Goals
+  preset: sustainable_development_goals
+  display_group: About the Data
+
+- start_form_page:
+    title: Indicator Specifics
+    description: Please provide further specific details about the indicator in question.
+
+  field_name: indicator_definition
+  label: Indicator Definition
+  form_placeholder: e.g.  The annual number of births to females aged 10-14 or 15-19 years per 1,000 females in the respective age group.
+  display_group: Indicator Details
+
+- field_name: direction_of_progress
+  label: Direction of Progress
+  form_placeholder: e.g.  Figures decreasing over time demonstrates progress.
+  display_group: Indicator Details
+
+- field_name: data_type
+  label: Data Type
+  form_placeholder: e.g. Float or Int
+  display_group: Indicator Details
+
+- field_name: unit_of_measure
+  label: Unit of Measure
+  form_placeholder: e.g. Annual number of births per 1000 adolescent women
+  display_group: Indicator Details
+
+- field_name: value_display_label
+  label: Value Display Label
+  form_placeholder: e.g. % or Births per 1000
+  help_text: Used in visualisations and charts
+  display_group: Indicator Details
+
+- field_name: short_value_display_label
+  label: Short Value Display Label
+  form_placeholder: e.g. % or Births per 1000
+  help_text: Used in visualisations and charts
+  display_group: Indicator Details
+
+- field_name: subject_of_measure
+  label: Subject Of Measure
+  form_placeholder: e.g. Natality
+  display_group: Indicator Details
+
+- field_name: subject_of_measure_sentiment
+  label: Subject Of Measure Sentiment
+  form_placeholder: e.g. Negativity
+  display_group: Indicator Details
+
+- field_name: confidence_intervals
+  label: Confidence Intervals
+  preset: yes_no
+  help_text: Are confidence intervals caluclated for the indicator?
+  display_group: Indicator Details
+
+- field_name: calculation_type
+  label: Calculation Type
+  form_placeholder: e.g. Adjusted or Predicted
+  display_group: Indicator Details
+
+- field_name: data_completeness
+  label: Data Completeness
+  form_placeholder: e.g. Incomplete
+  display_group: Indicator Details
 
 
 resource_fields:
@@ -146,4 +223,3 @@ resource_fields:
 - field_name: format
   label: Format
   preset: resource_format_autocomplete
-

--- a/ckanext/who_afro/schemas/indicator.yaml
+++ b/ckanext/who_afro/schemas/indicator.yaml
@@ -7,7 +7,12 @@ about_url: http://github.com/ckan/ckanext-scheming
 
 dataset_fields:
 
-- field_name: title
+- start_form_page:
+    title: General Metadata
+    description:
+      These fields provide an overview of the dataset, helping users to search and find relevant data within the catalogue.
+
+  field_name: title
   label: Title
   preset: title
   form_placeholder: eg. A descriptive title
@@ -22,21 +27,10 @@ dataset_fields:
   form_snippet: markdown.html
   form_placeholder: eg. Some useful notes about the data
 
-- field_name: programme
-  preset: programme
-
-- field_name: country
-  preset: country
-
 - field_name: tag_string
   label: Tags
   preset: tag_string_autocomplete
   form_placeholder: eg. economy, mental health, government
-
-- field_name: license_id
-  label: License
-  form_snippet: license.html
-  help_text: License definitions and additional information can be found at http://opendefinition.org/
 
 - field_name: maintainer
   label: Maintainer
@@ -48,6 +42,11 @@ dataset_fields:
   user_field: email
   form_snippet: user.html
   display_snippet: email.html
+
+- field_name: license_id
+  label: License
+  form_snippet: license.html
+  help_text: License definitions and additional information can be found at http://opendefinition.org/
 
 - field_name: owner_org
   label: Organization
@@ -66,9 +65,20 @@ dataset_fields:
   validators: boolean_validator
   output_validators: boolean_validator
 
+- start_form_page:
+    title: About the data
+    description: Please provide as many details as possible to facilitate the reuse of the data.
+
+  field_name: programme
+  preset: programme
+
+- field_name: country
+  preset: country
+
 - field_name: language
   label: Dataset Language
   preset: language
+
 
 resource_fields:
 

--- a/ckanext/who_afro/schemas/publication.yaml
+++ b/ckanext/who_afro/schemas/publication.yaml
@@ -66,6 +66,9 @@ dataset_fields:
   validators: boolean_validator
   output_validators: boolean_validator
 
+- field_name: language
+  label: Dataset Language
+  preset: language
 
 resource_fields:
 

--- a/ckanext/who_afro/schemas/publication.yaml
+++ b/ckanext/who_afro/schemas/publication.yaml
@@ -15,47 +15,58 @@ dataset_fields:
   field_name: title
   label: Title
   preset: title
+  required: true
   form_placeholder: eg. A descriptive title
 
 - field_name: name
   label: URL
   preset: dataset_slug
+  required: true
   form_placeholder: eg. my-dataset
 
-- field_name: notes
-  label: Description
-  form_snippet: markdown.html
-  form_placeholder: eg. Some useful notes about the data
+- field_name: country
+  required: true
+  preset: country
+
+- field_name: programm
+  required: true
+  preset: programme
 
 - field_name: tag_string
+  required: true
   label: Tags
   preset: tag_string_autocomplete
   form_placeholder: eg. economy, mental health, government
 
 - field_name: maintainer
   label: Maintainer
+  required: true
   user_field: fullname
   form_snippet: user.html
 
 - field_name: maintainer_email
   label: Maintainer Email
+  required: true
   user_field: email
   form_snippet: user.html
   display_snippet: email.html
 
 - field_name: license_id
+  required: true
   label: License
   form_snippet: license.html
   help_text: License definitions and additional information can be found at http://opendefinition.org/
 
 - field_name: owner_org
+  required: true
   label: Organization
   preset: dataset_organization
 
 - field_name: private
   label: Visibility
   help_text: Restrict access
-  help_inline: true
+  help_inline: false
+  required: true
   preset: select
   choices:
   - value: false
@@ -69,15 +80,49 @@ dataset_fields:
     title: About the data
     description: Please provide as many details as possible to facilitate the reuse of the data.
 
-  field_name: programme
-  preset: programme
+  field_name: accrual_periodicity
+  label: Accrual Periodicity
+  form_placeholder: e.g. Annual
+  help_text: Indicate how frequently new data is collected and consolidated into this dataset.
 
-- field_name: country
-  preset: country
+- field_name: provenance
+  label: Provenance
+  form_placeholder: e.g. Country, Territory or Area Reported
+  help_text: Briefly describe where the data comes from.
+
+- field_name: temporal_start
+  label: Temporaral Start Date
+  preset: date
+  help_text: For time series data, this should be the earliest date reported in the data.
+
+- field_name: temporal_end
+  label: Temporaral End Date
+  preset: date
+  help_text: For time series data, this should be the latest data reported in the data. Leave blank if dataset has an indefinte end.
+
+- field_name: temporal_resolution
+  label: Temporaral Resolution
+  form_placeholder: eg. Daily or Every 2 weeks
+  help_text: For time series data, this should be the minimum temporal difference represented in the data.
+
+- field_name: spatial_resolution
+  label: Spatial Resolution
+  form_placeholder: eg. Admin Level 1 (national) or Point Level or 100m2
+  help_text: For spatial data, this should be the minimum spatial difference represented in the data.
 
 - field_name: language
   label: Dataset Language
   preset: language
+
+- field_name: notes
+  label: Description
+  form_snippet: markdown.html
+  form_placeholder: Please give any useful notes about how to navigate and use the data.
+
+- field_name: source
+  label: Source
+  form_snippet: markdown.html
+  form_placeholder: Give specific further details about how the data was sourced.
 
 
 resource_fields:
@@ -94,3 +139,4 @@ resource_fields:
 - field_name: format
   label: Format
   preset: resource_format_autocomplete
+

--- a/ckanext/who_afro/schemas/publication.yaml
+++ b/ckanext/who_afro/schemas/publication.yaml
@@ -17,32 +17,44 @@ dataset_fields:
   preset: title
   required: true
   form_placeholder: eg. A descriptive title
+  display_group: Overview
 
 - field_name: name
   label: URL
   preset: dataset_slug
   required: true
   form_placeholder: eg. my-dataset
+  display_group: Overview
+
+- field_name: notes
+  required: true
+  label: Description
+  form_snippet: markdown.html
+  form_placeholder: Please give a useful introduction to the dataset which will be shown straight after the title.
 
 - field_name: country
   required: true
   preset: country
+  display_group: Overview
 
-- field_name: programm
+- field_name: programme
   required: true
   preset: programme
+  display_group: Overview
 
 - field_name: tag_string
   required: true
   label: Tags
   preset: tag_string_autocomplete
   form_placeholder: eg. economy, mental health, government
+  display_group: Overview
 
 - field_name: maintainer
   label: Maintainer
   required: true
   user_field: fullname
   form_snippet: user.html
+  display_group: Overview
 
 - field_name: maintainer_email
   label: Maintainer Email
@@ -50,21 +62,23 @@ dataset_fields:
   user_field: email
   form_snippet: user.html
   display_snippet: email.html
+  display_group: Overview
 
-- field_name: license_id
+- field_name: language
   required: true
-  label: License
-  form_snippet: license.html
-  help_text: License definitions and additional information can be found at http://opendefinition.org/
+  label: Dataset Language
+  preset: language
+  display_group: Overview
 
 - field_name: owner_org
   required: true
   label: Organization
   preset: dataset_organization
+  display_group: Access & Use
 
 - field_name: private
   label: Visibility
-  help_text: Restrict access
+  help_text: Public data is published under the "CC BY 4.0" license, private data is only visible to designated collaborators and members of the above-specified team.
   help_inline: false
   required: true
   preset: select
@@ -75,54 +89,66 @@ dataset_fields:
     label: Private
   validators: boolean_validator
   output_validators: boolean_validator
+  display_group: Access & Use
+
+- field_name: license_id
+  label: License
+  required: true
+  preset: preset_value
+  validators: who_license_autofill
+  display_group: Access & Use
+
 
 - start_form_page:
     title: About the data
     description: Please provide as many details as possible to facilitate the reuse of the data.
 
   field_name: accrual_periodicity
-  label: Accrual Periodicity
+  label: Frequency of data collection
   form_placeholder: e.g. Annual
-  help_text: Indicate how frequently new data is collected and consolidated into this dataset.
+  help_text: Indicate how frequently new data is incorporated into this dataset.
+  display_group: About the Data
 
 - field_name: provenance
   label: Provenance
-  form_placeholder: e.g. Country, Territory or Area Reported
-  help_text: Briefly describe where the data comes from.
+  form_placeholder: e.g. "Country reports" or "Household surveys"
+  help_text: Briefly describe where the data has come from.
+  display_group: About the Data
 
 - field_name: temporal_start
-  label: Temporaral Start Date
+  label: Temporal Start Date
   preset: date
   help_text: For time series data, this should be the earliest date reported in the data.
+  display_group: About the Data
 
 - field_name: temporal_end
-  label: Temporaral End Date
+  label: Temporal End Date
   preset: date
   help_text: For time series data, this should be the latest data reported in the data. Leave blank if dataset has an indefinte end.
+  display_group: About the Data
 
 - field_name: temporal_resolution
-  label: Temporaral Resolution
+  label: Temporal Resolution
   form_placeholder: eg. Daily or Every 2 weeks
   help_text: For time series data, this should be the minimum temporal difference represented in the data.
+  display_group: About the Data
 
 - field_name: spatial_resolution
   label: Spatial Resolution
   form_placeholder: eg. Admin Level 1 (national) or Point Level or 100m2
   help_text: For spatial data, this should be the minimum spatial difference represented in the data.
-
-- field_name: language
-  label: Dataset Language
-  preset: language
-
-- field_name: notes
-  label: Description
-  form_snippet: markdown.html
-  form_placeholder: Please give any useful notes about how to navigate and use the data.
+  display_group: About the Data
 
 - field_name: source
   label: Source
   form_snippet: markdown.html
   form_placeholder: Give specific further details about how the data was sourced.
+  display_group: About the Data
+
+- field_name: sustainable_development_goals
+  label: Sustainable Development Goals
+  preset: sustainable_development_goals
+  display_group: About the Data
 
 
 resource_fields:
@@ -139,4 +165,3 @@ resource_fields:
 - field_name: format
   label: Format
   preset: resource_format_autocomplete
-

--- a/ckanext/who_afro/schemas/publication.yaml
+++ b/ckanext/who_afro/schemas/publication.yaml
@@ -7,7 +7,12 @@ about_url: http://github.com/ckan/ckanext-scheming
 
 dataset_fields:
 
-- field_name: title
+- start_form_page:
+    title: General Metadata
+    description:
+      These fields provide an overview of the dataset, helping users to search and find relevant data within the catalogue.
+
+  field_name: title
   label: Title
   preset: title
   form_placeholder: eg. A descriptive title
@@ -22,21 +27,10 @@ dataset_fields:
   form_snippet: markdown.html
   form_placeholder: eg. Some useful notes about the data
 
-- field_name: programme
-  preset: programme
-
-- field_name: country
-  preset: country
-
 - field_name: tag_string
   label: Tags
   preset: tag_string_autocomplete
   form_placeholder: eg. economy, mental health, government
-
-- field_name: license_id
-  label: License
-  form_snippet: license.html
-  help_text: License definitions and additional information can be found at http://opendefinition.org/
 
 - field_name: maintainer
   label: Maintainer
@@ -48,6 +42,11 @@ dataset_fields:
   user_field: email
   form_snippet: user.html
   display_snippet: email.html
+
+- field_name: license_id
+  label: License
+  form_snippet: license.html
+  help_text: License definitions and additional information can be found at http://opendefinition.org/
 
 - field_name: owner_org
   label: Organization
@@ -66,9 +65,20 @@ dataset_fields:
   validators: boolean_validator
   output_validators: boolean_validator
 
+- start_form_page:
+    title: About the data
+    description: Please provide as many details as possible to facilitate the reuse of the data.
+
+  field_name: programme
+  preset: programme
+
+- field_name: country
+  preset: country
+
 - field_name: language
   label: Dataset Language
   preset: language
+
 
 resource_fields:
 

--- a/ckanext/who_afro/schemas/source.yaml
+++ b/ckanext/who_afro/schemas/source.yaml
@@ -17,32 +17,44 @@ dataset_fields:
   preset: title
   required: true
   form_placeholder: eg. A descriptive title
+  display_group: Overview
 
 - field_name: name
   label: URL
   preset: dataset_slug
   required: true
   form_placeholder: eg. my-dataset
+  display_group: Overview
+
+- field_name: notes
+  required: true
+  label: Description
+  form_snippet: markdown.html
+  form_placeholder: Please give a useful introduction to the dataset which will be shown straight after the title.
 
 - field_name: country
   required: true
   preset: country
+  display_group: Overview
 
-- field_name: programm
+- field_name: programme
   required: true
   preset: programme
+  display_group: Overview
 
 - field_name: tag_string
   required: true
   label: Tags
   preset: tag_string_autocomplete
   form_placeholder: eg. economy, mental health, government
+  display_group: Overview
 
 - field_name: maintainer
   label: Maintainer
   required: true
   user_field: fullname
   form_snippet: user.html
+  display_group: Overview
 
 - field_name: maintainer_email
   label: Maintainer Email
@@ -50,21 +62,23 @@ dataset_fields:
   user_field: email
   form_snippet: user.html
   display_snippet: email.html
+  display_group: Overview
 
-- field_name: license_id
+- field_name: language
   required: true
-  label: License
-  form_snippet: license.html
-  help_text: License definitions and additional information can be found at http://opendefinition.org/
+  label: Dataset Language
+  preset: language
+  display_group: Overview
 
 - field_name: owner_org
   required: true
   label: Organization
   preset: dataset_organization
+  display_group: Access & Use
 
 - field_name: private
   label: Visibility
-  help_text: Restrict access
+  help_text: Public data is published under the "CC BY 4.0" license, private data is only visible to designated collaborators and members of the above-specified team.
   help_inline: false
   required: true
   preset: select
@@ -75,54 +89,66 @@ dataset_fields:
     label: Private
   validators: boolean_validator
   output_validators: boolean_validator
+  display_group: Access & Use
+
+- field_name: license_id
+  label: License
+  required: true
+  preset: preset_value
+  validators: who_license_autofill
+  display_group: Access & Use
+
 
 - start_form_page:
     title: About the data
     description: Please provide as many details as possible to facilitate the reuse of the data.
 
   field_name: accrual_periodicity
-  label: Accrual Periodicity
+  label: Frequency of data collection
   form_placeholder: e.g. Annual
-  help_text: Indicate how frequently new data is collected and consolidated into this dataset.
+  help_text: Indicate how frequently new data is incorporated into this dataset.
+  display_group: About the Data
 
 - field_name: provenance
   label: Provenance
-  form_placeholder: e.g. Country, Territory or Area Reported
-  help_text: Briefly describe where the data comes from.
+  form_placeholder: e.g. "Country reports" or "Household surveys"
+  help_text: Briefly describe where the data has come from.
+  display_group: About the Data
 
 - field_name: temporal_start
-  label: Temporaral Start Date
+  label: Temporal Start Date
   preset: date
   help_text: For time series data, this should be the earliest date reported in the data.
+  display_group: About the Data
 
 - field_name: temporal_end
-  label: Temporaral End Date
+  label: Temporal End Date
   preset: date
   help_text: For time series data, this should be the latest data reported in the data. Leave blank if dataset has an indefinte end.
+  display_group: About the Data
 
 - field_name: temporal_resolution
-  label: Temporaral Resolution
+  label: Temporal Resolution
   form_placeholder: eg. Daily or Every 2 weeks
   help_text: For time series data, this should be the minimum temporal difference represented in the data.
+  display_group: About the Data
 
 - field_name: spatial_resolution
   label: Spatial Resolution
   form_placeholder: eg. Admin Level 1 (national) or Point Level or 100m2
   help_text: For spatial data, this should be the minimum spatial difference represented in the data.
-
-- field_name: language
-  label: Dataset Language
-  preset: language
-
-- field_name: notes
-  label: Description
-  form_snippet: markdown.html
-  form_placeholder: Please give any useful notes about how to navigate and use the data.
+  display_group: About the Data
 
 - field_name: source
   label: Source
   form_snippet: markdown.html
   form_placeholder: Give specific further details about how the data was sourced.
+  display_group: About the Data
+
+- field_name: sustainable_development_goals
+  label: Sustainable Development Goals
+  preset: sustainable_development_goals
+  display_group: About the Data
 
 
 resource_fields:
@@ -139,6 +165,3 @@ resource_fields:
 - field_name: format
   label: Format
   preset: resource_format_autocomplete
-
-
-

--- a/ckanext/who_afro/schemas/source.yaml
+++ b/ckanext/who_afro/schemas/source.yaml
@@ -66,6 +66,9 @@ dataset_fields:
   validators: boolean_validator
   output_validators: boolean_validator
 
+- field_name: language
+  label: Dataset Language
+  preset: language
 
 resource_fields:
 

--- a/ckanext/who_afro/schemas/source.yaml
+++ b/ckanext/who_afro/schemas/source.yaml
@@ -7,7 +7,12 @@ about_url: http://github.com/ckan/ckanext-scheming
 
 dataset_fields:
 
-- field_name: title
+- start_form_page:
+    title: General Metadata
+    description:
+      These fields provide an overview of the dataset, helping users to search and find relevant data within the catalogue.
+
+  field_name: title
   label: Title
   preset: title
   form_placeholder: eg. A descriptive title
@@ -22,21 +27,10 @@ dataset_fields:
   form_snippet: markdown.html
   form_placeholder: eg. Some useful notes about the data
 
-- field_name: programme
-  preset: programme
-
-- field_name: country
-  preset: country
-
 - field_name: tag_string
   label: Tags
   preset: tag_string_autocomplete
   form_placeholder: eg. economy, mental health, government
-
-- field_name: license_id
-  label: License
-  form_snippet: license.html
-  help_text: License definitions and additional information can be found at http://opendefinition.org/
 
 - field_name: maintainer
   label: Maintainer
@@ -48,6 +42,11 @@ dataset_fields:
   user_field: email
   form_snippet: user.html
   display_snippet: email.html
+
+- field_name: license_id
+  label: License
+  form_snippet: license.html
+  help_text: License definitions and additional information can be found at http://opendefinition.org/
 
 - field_name: owner_org
   label: Organization
@@ -66,9 +65,20 @@ dataset_fields:
   validators: boolean_validator
   output_validators: boolean_validator
 
+- start_form_page:
+    title: About the data
+    description: Please provide as many details as possible to facilitate the reuse of the data.
+
+  field_name: programme
+  preset: programme
+
+- field_name: country
+  preset: country
+
 - field_name: language
   label: Dataset Language
   preset: language
+
 
 resource_fields:
 
@@ -84,3 +94,5 @@ resource_fields:
 - field_name: format
   label: Format
   preset: resource_format_autocomplete
+
+

--- a/ckanext/who_afro/schemas/source.yaml
+++ b/ckanext/who_afro/schemas/source.yaml
@@ -15,47 +15,58 @@ dataset_fields:
   field_name: title
   label: Title
   preset: title
+  required: true
   form_placeholder: eg. A descriptive title
 
 - field_name: name
   label: URL
   preset: dataset_slug
+  required: true
   form_placeholder: eg. my-dataset
 
-- field_name: notes
-  label: Description
-  form_snippet: markdown.html
-  form_placeholder: eg. Some useful notes about the data
+- field_name: country
+  required: true
+  preset: country
+
+- field_name: programm
+  required: true
+  preset: programme
 
 - field_name: tag_string
+  required: true
   label: Tags
   preset: tag_string_autocomplete
   form_placeholder: eg. economy, mental health, government
 
 - field_name: maintainer
   label: Maintainer
+  required: true
   user_field: fullname
   form_snippet: user.html
 
 - field_name: maintainer_email
   label: Maintainer Email
+  required: true
   user_field: email
   form_snippet: user.html
   display_snippet: email.html
 
 - field_name: license_id
+  required: true
   label: License
   form_snippet: license.html
   help_text: License definitions and additional information can be found at http://opendefinition.org/
 
 - field_name: owner_org
+  required: true
   label: Organization
   preset: dataset_organization
 
 - field_name: private
   label: Visibility
   help_text: Restrict access
-  help_inline: true
+  help_inline: false
+  required: true
   preset: select
   choices:
   - value: false
@@ -69,15 +80,49 @@ dataset_fields:
     title: About the data
     description: Please provide as many details as possible to facilitate the reuse of the data.
 
-  field_name: programme
-  preset: programme
+  field_name: accrual_periodicity
+  label: Accrual Periodicity
+  form_placeholder: e.g. Annual
+  help_text: Indicate how frequently new data is collected and consolidated into this dataset.
 
-- field_name: country
-  preset: country
+- field_name: provenance
+  label: Provenance
+  form_placeholder: e.g. Country, Territory or Area Reported
+  help_text: Briefly describe where the data comes from.
+
+- field_name: temporal_start
+  label: Temporaral Start Date
+  preset: date
+  help_text: For time series data, this should be the earliest date reported in the data.
+
+- field_name: temporal_end
+  label: Temporaral End Date
+  preset: date
+  help_text: For time series data, this should be the latest data reported in the data. Leave blank if dataset has an indefinte end.
+
+- field_name: temporal_resolution
+  label: Temporaral Resolution
+  form_placeholder: eg. Daily or Every 2 weeks
+  help_text: For time series data, this should be the minimum temporal difference represented in the data.
+
+- field_name: spatial_resolution
+  label: Spatial Resolution
+  form_placeholder: eg. Admin Level 1 (national) or Point Level or 100m2
+  help_text: For spatial data, this should be the minimum spatial difference represented in the data.
 
 - field_name: language
   label: Dataset Language
   preset: language
+
+- field_name: notes
+  label: Description
+  form_snippet: markdown.html
+  form_placeholder: Please give any useful notes about how to navigate and use the data.
+
+- field_name: source
+  label: Source
+  form_snippet: markdown.html
+  form_placeholder: Give specific further details about how the data was sourced.
 
 
 resource_fields:
@@ -94,5 +139,6 @@ resource_fields:
 - field_name: format
   label: Format
   preset: resource_format_autocomplete
+
 
 

--- a/ckanext/who_afro/templates/scheming/display_snippets/language.html
+++ b/ckanext/who_afro/templates/scheming/display_snippets/language.html
@@ -1,0 +1,5 @@
+{%- for locale in h.get_available_locales() -%}
+    {%- if locale.short_name == data[field.field_name] -%}
+        {{h.format_locale(locale)}}
+    {%- endif -%}
+{%- endfor -%}

--- a/ckanext/who_afro/templates/scheming/display_snippets/language.html
+++ b/ckanext/who_afro/templates/scheming/display_snippets/language.html
@@ -1,5 +1,5 @@
 {%- for locale in h.get_available_locales() -%}
     {%- if locale.short_name == data[field.field_name] -%}
-        {{h.format_locale(locale)}}
+        {{h.format_locale(locale)}} ({{locale.short_name}})
     {%- endif -%}
 {%- endfor -%}

--- a/ckanext/who_afro/templates/scheming/display_snippets/multiple_inline.html
+++ b/ckanext/who_afro/templates/scheming/display_snippets/multiple_inline.html
@@ -1,0 +1,17 @@
+{%- set values = data[field.field_name] -%}
+{%- set labels = [] -%}
+
+{%- for choice in h.scheming_field_choices(field) -%}
+    {%- if choice.value in values -%}
+      {%- do labels.append(h.scheming_language_text(choice.label)) -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- if labels|length == 1 -%}
+  {{ labels[0] }}
+{%- else -%}
+    {%- if field.get('sorted_choices') -%}
+        {%- set labels = labels|sort -%}
+    {%- endif -%}
+    {{field.get('separator', "; ").join(labels)}}
+{%- endif -%}

--- a/ckanext/who_afro/templates/scheming/form_snippets/language.html
+++ b/ckanext/who_afro/templates/scheming/form_snippets/language.html
@@ -1,0 +1,28 @@
+{% import 'macros/form.html' as form %}
+{% set website_current_lang = request.environ.CKAN_LANG %}
+{%- set options = [] -%}
+{%- for locale in h.get_available_locales() -%}
+    {%- do options.append({"text": h.format_locale(locale), "value": locale.short_name}) -%}
+{%- endfor -%}
+
+{%- if data[field.field_name] -%}
+  {%- set option_selected = data[field.field_name]|string -%}
+{%- else -%}
+  {%- set option_selected = website_current_lang|string -%}
+{%- endif -%}
+
+{%
+    call form.select(
+        field.field_name,
+        id='field-' + field.field_name,
+        label=h.scheming_language_text(field.label),
+        options=options,
+        selected=option_selected,
+        error=errors[field.field_name],
+        classes=field.classes if 'classes' in field else ['control-medium'],
+        attrs=dict({"class": "form-control"}, **(field.get('form_attrs', {}))),
+        is_required=h.scheming_field_required(field)
+    )
+%}
+    {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
+{% endcall %}

--- a/ckanext/who_afro/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/who_afro/templates/scheming/package/snippets/additional_info.html
@@ -1,0 +1,42 @@
+{%- set exclude_fields = [
+    'id',
+    'title',
+    'name',
+    'notes',
+    'tag_string',
+    'license_id',
+    'owner_org',
+    ] -%}
+{%- set schema = h.scheming_get_dataset_schema(dataset_type) -%} 
+
+<section class="additional-info">
+  <h2 class="addition-info-title">{{ _('Metadata') }}</h2>
+
+  {%- for group in schema.dataset_fields|groupby('display_group', default="Overview")|reverse -%}
+    {%- set group_fields = [] -%}
+    {%- for field in group.list -%}
+      {%- if field.field_name not in exclude_fields
+          and field.display_snippet is not none
+          and pkg_dict.get(field.field_name) -%}
+        {%- do group_fields.append(field) -%}
+      {%- endif -%}
+    {%- endfor -%}
+    {%- if group_fields != [] -%}
+      <h3 class="scheming-group-title">
+        {{ _(group.grouper) }}
+      </h3>
+      <table class="table table-striped table-bordered table-condensed">
+      {%- for field in group_fields -%}
+          <tr>
+            <th scope="row" class="dataset-label">{{
+              h.scheming_language_text(field.label) }}</th>
+            <td class="dataset-details"{%
+              if field.display_property %} property="{{ field.display_property
+              }}"{% endif %}>{%- snippet 'scheming/snippets/display_field.html',
+              field=field, data=pkg_dict, schema=schema -%}</td>
+          </tr>
+      {%- endfor -%}
+      </table>
+    {%- endif -%}
+  {% endfor %}
+</section>

--- a/ckanext/who_afro/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/who_afro/templates/scheming/package/snippets/additional_info.html
@@ -28,7 +28,7 @@
       <table class="table table-striped table-bordered table-condensed">
       {%- for field in group_fields -%}
           <tr>
-            <th scope="row" class="dataset-label">{{
+            <th scope="row" class="dataset-label"  style="width:25%">{{
               h.scheming_language_text(field.label) }}</th>
             <td class="dataset-details"{%
               if field.display_property %} property="{{ field.display_property

--- a/ckanext/who_afro/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/who_afro/templates/scheming/package/snippets/additional_info.html
@@ -4,9 +4,19 @@
     'name',
     'notes',
     'tag_string',
-    'license_id',
     'owner_org',
+    'private',
+    'license_id',
+    'disclaimer',
+    'prohibited_uses'
     ] -%}
+
+{%- set license_fields = [
+    (_('Use'), 'license_text'),
+    (_('Disclaimer'), 'disclaimer'),
+    (_('Prohibited Uses'), 'prohibited_uses'),
+    ] -%}
+
 {%- set schema = h.scheming_get_dataset_schema(dataset_type) -%} 
 
 <section class="additional-info">
@@ -39,4 +49,44 @@
       </table>
     {%- endif -%}
   {% endfor %}
+  {%- set license = h.get_license(pkg_dict.get('license_id', "no_license")) -%}
+  {%- if license -%}
+      <h3 class="scheming-group-title">
+        {{ _("Access & Use") }}
+      </h3>
+      <table class="table table-striped table-bordered table-condensed">
+          <tr>
+            <th scope="row" class="dataset-label"  style="width:25%">{{_('Visibility')}}</th>
+            <td class="dataset-details">
+              {%- if pkg_dict.get('private', True) -%}
+                {%- set org_title = pkg_dict.get('organization', {}).get('title', 'ORG NOT FOUND') -%}
+                {{_("Private dataset - visible only to users who are members of \"{}\" or who have been specially designated as collaborators on this dataset.".format(org_title))}}
+              {%- else -%}
+                {{_("Publicly accessible")}}
+              {%- endif -%}
+            </td>
+          </tr>
+          <tr>
+            <th scope="row" class="dataset-label"  style="width:25%">{{_('License')}}</th>
+            <td class="dataset-details">
+              {%- if license.get('url') -%}
+                <a href="{{license['url']}}" target="_blank">{{license["title"]}} ({{license['id']}}) </a>
+              {%- else -%}
+                {{license["title"]}} ({{license["id"]}})
+              {%- endif -%}
+            </td>
+          </tr>
+          {%- for (license_field_label, license_field) in license_fields -%}
+            {%- set license_field_content = pkg_dict.get(license_field, license.get(license_field, "")) -%}
+            {%- if license_field_content -%}
+            <tr>
+              <th scope="row" class="dataset-label"  style="width:25%">{{license_field_label}}</th>
+              <td class="dataset-details">
+                {{ h.render_markdown(license_field_content) }}
+              </td>
+            </tr>
+            {%- endif -%}
+          {%- endfor -%}
+      </table>
+  {%- endif -%}
 </section>

--- a/ckanext/who_afro/tests/schemas/language_validator.yaml
+++ b/ckanext/who_afro/tests/schemas/language_validator.yaml
@@ -1,0 +1,24 @@
+scheming_version: 2
+dataset_type: language-validator
+name: Language Validator
+about: A test schema to test the validator language_validator
+about_url: http://github.com/ckan/ckanext-scheming
+
+
+dataset_fields:
+
+- field_name: title
+  label: Projection Title
+  preset: title
+  form_placeholder: eg. A descriptive filename
+  validators: not_empty unicode_safe
+
+- field_name: language
+  label: Dataset Language
+  preset: language
+
+
+resource_fields:
+
+- field_name: name
+  label: Name

--- a/ckanext/who_afro/tests/schemas/who_license_autofill.yaml
+++ b/ckanext/who_afro/tests/schemas/who_license_autofill.yaml
@@ -1,0 +1,42 @@
+scheming_version: 2
+dataset_type: who-license-autofill-validator
+name: WHO License Autofill Validator
+about: A test schema to test the validator who_license_autofill
+about_url: http://github.com/ckan/ckanext-scheming
+
+
+dataset_fields:
+
+- field_name: title
+  label: Projection Title
+  preset: title
+  form_placeholder: eg. A descriptive filename
+  validators: not_empty unicode_safe
+
+- field_name: private
+  label: Visibility
+  help_text: Public data is published under the "CC BY 4.0" license, private data is only visible to designated collaborators and members of the above-specified team.
+  help_inline: false
+  required: true
+  preset: select
+  choices:
+  - value: false
+    label: Public
+  - value: true
+    label: Private
+  validators: boolean_validator
+  output_validators: boolean_validator
+  display_group: Access & Use
+
+- field_name: license_id
+  label: License
+  required: true
+  preset: preset_value
+  validators: who_license_autofill
+  display_group: Access & Use
+
+
+resource_fields:
+
+- field_name: name
+  label: Name

--- a/ckanext/who_afro/tests/test_helpers.py
+++ b/ckanext/who_afro/tests/test_helpers.py
@@ -1,0 +1,14 @@
+import pytest
+from ckanext.who_afro import helpers as who_afro_helpers
+
+
+class TestGetLicense():
+
+    @pytest.mark.parametrize("license, expected_title", [
+        ('cc-by', 'Creative Commons Attribution'),
+        ('other-closed', "Other (Not Open)"),
+        ('non-existant-id', None)
+    ])
+    def test_get_license(self, license, expected_title):
+        license_dict = who_afro_helpers.get_license(license)
+        assert license_dict.get('title') == expected_title

--- a/ckanext/who_afro/tests/test_validators.py
+++ b/ckanext/who_afro/tests/test_validators.py
@@ -124,3 +124,24 @@ class TestLanguageValidator(object):
     def test_rejects_invalid_languages(self, language):
         with pytest.raises(ValidationError, match="Language of the dataset must be"):
             assert self._create_dataset(language=language)
+
+
+@pytest.mark.usefixtures("clean_db", "clean_index", "with_plugins")
+class TestLicenseAutofillValidator(object):
+
+    def _create_dataset(self, **kwargs):
+        return call_action(
+            "package_create",
+            type="who-license-autofill-validator",
+            title="Test Dataset",
+            name="test-dataset",
+            **kwargs
+        )
+
+    def test_private_true(self):
+        dataset = self._create_dataset(private=True)
+        assert dataset['license_id'] == 'who-closed'
+
+    def test_private_false(self):
+        dataset = self._create_dataset(private=False)
+        assert dataset['license_id'] == 'CC-BY-4.0'

--- a/ckanext/who_afro/tests/test_validators.py
+++ b/ckanext/who_afro/tests/test_validators.py
@@ -102,3 +102,25 @@ class TestAutofill(object):
         assert dataset['schema'] == u'art_4'
         assert dataset['dataset_type'] == u'different-data-type'
         assert dataset['year'] == u'1984'
+
+
+@pytest.mark.usefixtures("clean_db", "clean_index", "with_plugins")
+class TestLanguageValidator(object):
+
+    def _create_dataset(self, **kwargs):
+        return call_action(
+            "package_create",
+            type="language-validator",
+            title="Test Dataset",
+            name="test-dataset",
+            **kwargs
+        )
+
+    @pytest.mark.parametrize('language', ["en_GB", "fr", "pt_PT"])
+    def test_accepts_valid_languages(self, language):
+        assert self._create_dataset(language=language)
+
+    @pytest.mark.parametrize('language', ["blah", "en", "234"])
+    def test_rejects_invalid_languages(self, language):
+        with pytest.raises(ValidationError, match="Language of the dataset must be"):
+            assert self._create_dataset(language=language)

--- a/ckanext/who_afro/validators.py
+++ b/ckanext/who_afro/validators.py
@@ -5,7 +5,7 @@ from ckanext.who_afro.helpers import (
     month_formatter
 )
 from ckan.logic.validators import package_name_validator
-from ckan.plugins.toolkit import ValidationError, _, h
+from ckan.plugins.toolkit import ValidationError, _, h, get_validator
 from string import ascii_lowercase
 from random import choice
 import copy
@@ -88,6 +88,20 @@ def autofill(field, schema):
     def validator(key, data, errors, context):
         if not data.get(key):
             data[key] = field_value
+
+    return validator
+
+
+@scheming_validator
+def who_license_autofill(field, schema):
+    field_value = field.get(u'field_value', field.get('default', ''))
+
+    def validator(key, data, errors, context):
+        private_dataset = get_validator('boolean_validator')(data.get(("private",), True), {})
+        if private_dataset:
+            data[key] = "who-closed"
+        else:
+            data[key] = "CC-BY-4.0"
 
     return validator
 

--- a/ckanext/who_afro/validators.py
+++ b/ckanext/who_afro/validators.py
@@ -5,7 +5,7 @@ from ckanext.who_afro.helpers import (
     month_formatter
 )
 from ckan.logic.validators import package_name_validator
-from ckan.plugins.toolkit import ValidationError, _
+from ckan.plugins.toolkit import ValidationError, _, h
 from string import ascii_lowercase
 from random import choice
 import copy
@@ -100,4 +100,16 @@ def isomonth(field, schema):
                 month_formatter(data[key])
             except ValueError:
                 raise ValidationError({'name': [_('Month should be of the form yyyy-mm')]})
+    return validator
+
+
+@scheming_validator
+def language_validator(field, schema):
+    languages = [locale.short_name for locale in h.get_available_locales()]
+
+    def validator(key, data, errors, context):
+        if data.get(key) and data.get(key) not in languages:
+            raise ValidationError({'language': [_(
+                f'Language of the dataset must be one of: {", ".join(languages)}'
+            )]})
     return validator

--- a/ckanext/who_afro/validators.py
+++ b/ckanext/who_afro/validators.py
@@ -99,7 +99,9 @@ def isomonth(field, schema):
             try:
                 month_formatter(data[key])
             except ValueError:
-                raise ValidationError({'name': [_('Month should be of the form yyyy-mm')]})
+                errors[key].append(
+                    _('Month should be of the form yyyy-mm')
+                )
     return validator
 
 
@@ -109,7 +111,7 @@ def language_validator(field, schema):
 
     def validator(key, data, errors, context):
         if data.get(key) and data.get(key) not in languages:
-            raise ValidationError({'language': [_(
-                f'Language of the dataset must be one of: {", ".join(languages)}'
-            )]})
+            errors[key].append(
+                _(f'Language of the dataset must be one of: {", ".join(languages)}')
+            )
     return validator

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,7 @@
 pytest-ckan
+pytest-factoryboy
+pytest-cov
+pytest-freezegun
 zxcvbn
 mock
 pytest-recording

--- a/test.ini
+++ b/test.ini
@@ -18,6 +18,7 @@ ckan.locales_filtered_out = en
 scheming.dataset_schemas = ckanext.who_afro:tests/schemas/auto_generate_name_from_title.yaml
                            ckanext.who_afro:tests/schemas/language_validator.yaml
                            ckanext.who_afro:tests/schemas/autofill.json
+                           ckanext.who_afro:tests/schemas/who_license_autofill.yaml
 
 scheming.presets = ckanext.scheming:presets.json
                    ckanext.who_afro:presets.json

--- a/test.ini
+++ b/test.ini
@@ -10,9 +10,17 @@ use = config:../ckan/test-core.ini
 # tests here. These will override the one defined in CKAN core's test-core.ini
 ckan.plugins = who_afro scheming_datasets activity
 ckan.auth.allow_dataset_collaborators = true
+ckan.locale_default = en_GB
+ckan.locale_order = en_GB fr pt_PT
+ckan.locales_offered = en_GB fr pt_PT
+ckan.locales_filtered_out = en
 
 scheming.dataset_schemas = ckanext.who_afro:tests/schemas/auto_generate_name_from_title.yaml
+                           ckanext.who_afro:tests/schemas/language_validator.yaml
                            ckanext.who_afro:tests/schemas/autofill.json
+
+scheming.presets = ckanext.scheming:presets.json
+                   ckanext.who_afro:presets.json
 
 # Logging configuration
 [loggers]


### PR DESCRIPTION
## Description

Implements a series of metadata changes consistent with what is documented in the [dataset catalogue design](https://docs.google.com/document/d/1U71n8d8VntNti_YawAGaSNzfgw3PmVULWR-ASyT3n9k/edit). 

Specifically associates disclaimers and license details with the available licenses so that these can be shown in page along side the data. 

Also needs: https://github.com/fjelltopp/fjelltopp-infrastructure/pull/237

To see the changes, just create a new "indicator" dataset.  You should find a four part broken down form to enter in a variety of different metadata. Also, view the dataset and you should see a list of tables with metadata structured in a better way.

Matters arising from this PR:

- Do we really need source.yaml and publication.yaml schemas?  I don't think so any more - I think inidcator.yaml and general dataset.yaml is all we need at the moment, but deleting them will be a problem if we have datasets created with them.  We'll need to first delete any sources / publications in the demo data loader, and the cloud instance, before deploying such a change.
- How do we best translate preset / schema / license content?  Ideally we would write our own babel message extractor.  The interim solution used in other projects is to duplicate all relevant strings [here](https://github.com/fjelltopp/ckanext-who-afro/blob/master/ckanext/who_afro/i18n/extra_translations.py). 

## Testing

Tests added for python code:

- get_license helper - retrieves the metadata for a given license ID
- who_autofill_license validator - autofills the license Id based on the visibility of the dataset.

My tests broke in github actions but worked locally.  This turned out to be because we are using a ckan image with the wrong version of ckan installed in our github actions.  Also the image we have been using is now deprecated anyway. I have therefore had to update the image used in github actions to use the ckan version we are developing with locally (v2.10.4). I have also had to install a few extra dev-dependancies to get pytest working again. 

## Documentation 

Worth checking out the [dataset catalogue design](https://docs.google.com/document/d/1U71n8d8VntNti_YawAGaSNzfgw3PmVULWR-ASyT3n9k/edit) document.  

## Internationalisation and Localisation

All strings should be internationalised appropriately. Though it is worth clocking that we currently do not have a good solution for internationalising schema, preset and license strings.  

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [x] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [x] New dependency changes have been committed.
- [x] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
