### PR TITLE
feat: add javascript for updating search params when using the new sort options

### DIFF
--- a/ckanext/who_afro/templates/package/search.html
+++ b/ckanext/who_afro/templates/package/search.html
@@ -64,14 +64,14 @@
 
 
 {% block secondary_content %}
-  {% set sorting = [(_('Relevance'), 'relevance'), (_('Name Ascending'), 'name asc'), (_('Name Descending'), 'name desc')] %}
-
+  {% set sorting = [(_('Relevance'), 'score desc, metadata_modified desc'), (_('Name Ascending'), 'name asc'), (_('Name Descending'), 'name desc')] %}
+  {% set sorting_selected = request.args.get('sort') %}
   <div class="filters">
     <div>
       <h3>{{ _('Order by:') }}</h3>
       <div class="form-group control-order-by">
         <!-- <label for="field-order-by">{{ _('Order by') }}</label> -->
-        <select id="field-order-by" name="sort" class="form-control form-select">
+        <select id="field-order-by" name="sort" class="form-control form-select" onchange="setSort(this.value);">
           {% for label, value in sorting %}
             {% if label and value %}
               <option value="{{ value }}"{% if sorting_selected == value %} selected="selected"{% endif %}>{{ label }}</option>
@@ -93,6 +93,13 @@
     </div>
     <a class="close no-text hide-filters"><i class="fa fa-times-circle"></i><span class="text">close</span></a>
   </div>
+  <script>
+    const url = new URL(window.location.href);
+    function setSort(sort_value) {
+      url.searchParams.set('sort', sort_value);
+      window.location.href = url;
+    }
+  </script>
 {% endblock %}
 
 {% block form %}

--- a/ckanext/who_afro/templates/snippets/facet_list.html
+++ b/ckanext/who_afro/templates/snippets/facet_list.html
@@ -14,8 +14,16 @@
 			</h2>
 		    {% endblock %}
 		    {% block facet_list_items %}
-                {% with items = items or h.get_facet_items_dict(name, search_facets) %}
-                    {% if items %}
+			{% with items = items or h.get_facet_items_dict(name, search_facets) %}
+			    {% if items %}
+                    {% for item in items %}
+                        {% do item.update({'display_name': h.scheming_choices_label(scheming_choices, item.name)
+                        if scheming_choices else item.display_name}) %}
+                    {% endfor %}
+                    <div id="{{ title }}-collapse" class="accordion-collapse collapse show" aria-labelledby="{{ title }}-heading" data-bs-parent="#filters">
+                    <nav aria-label="{{ title }}">
+                        <input type="text" id="{{ title }}-search" onkeyup="filterFacets('{{ title }}', this.value);" placeholder="Search {{ title }}..">
+                        <ul class="list-unstyled nav nav-simple nav-facet" id="{{ title }}-list">
                         {% for item in items %}
                             {% do item.update({'display_name': h.scheming_choices_label(scheming_choices, item.name)
                             if scheming_choices else item.display_name}) %}
@@ -46,6 +54,25 @@
                 {% endwith %}
 		    {% endblock %}
 		</section>
+        <script>
+            function filterFacets(facetTitle, searchTerm) {
+              const input = document.getElementById(`${facetTitle}-search`);
+              const filter = searchTerm.toUpperCase();
+              const ul = document.getElementById(`${facetTitle}-list`);
+              const li = ul.getElementsByTagName('li');
+            
+              // Loop through all list items, and hide those who don't match the search query
+              for (i = 0; i < li.length; i++) {
+                const span = li[i].getElementsByClassName("item-label")[0];
+                const txtValue = span.textContent || span.innerText;
+                if (txtValue.toUpperCase().indexOf(filter) > -1) {
+                  li[i].style.display = "";
+                } else {
+                  li[i].style.display = "none";
+                }
+              }
+            }
+        </script>
 	    {% endblock %}
 	{% endif %}
     {% endwith %}


### PR DESCRIPTION
## Description

This is essentially the quickest solution to making the sort `select` work. It's pretty tidy but I'm not overly happy about putting the JS in the page - that might change as I add other JS features.

## Checklist

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
