### PR TITLE
fix: use the default header for admin pages

### DIFF
--- a/ckanext/who_afro/templates/admin/base.html
+++ b/ckanext/who_afro/templates/admin/base.html
@@ -4,10 +4,6 @@
     {% set user_dict = h.get_user_obj() %}
 {% endif %}
 
-{%- block header %}
-    {% include "user/account_header.html" %}
-{% endblock -%}
-
 {% block breadcrumb %}
     {% if self.breadcrumb_content() | trim %}
       <ol class="profile-page breadcrumb">


### PR DESCRIPTION
## Description

As it says on the tin :canned_food: 

PR #48 removed this snippet but just missed that the admin pages were still using it; this corrects for that.

## Checklist

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
