### PR TITLE
WAC-115: Fix footer margins about WHO logo and reposition the background image on the right side.

### DIFF
--- a/ckanext/who_afro/assets/css/footer-background.css
+++ b/ckanext/who_afro/assets/css/footer-background.css
@@ -7,6 +7,10 @@
     background-repeat: no-repeat;
 }
 
+.footer-bg.bottom-right.loggedin {
+    bottom: -25px;
+}
+
 @media (max-width: 3000px) {
     .footer-bg.bottom-right {
         left: calc(100% - 600px);

--- a/ckanext/who_afro/assets/css/who-afro.css
+++ b/ckanext/who_afro/assets/css/who-afro.css
@@ -2117,6 +2117,10 @@ footer.site-footer .subscribe > .container > .highlight-box > .row > div:first-c
     max-width: 100% !important;
 }
 
+footer.site-footer .empty-subscribe {
+    margin-top: 64px
+}
+
 footer.site-footer .data-hub-stats {
     margin-left: 0;
     height: auto;

--- a/ckanext/who_afro/templates/footer.html
+++ b/ckanext/who_afro/templates/footer.html
@@ -1,7 +1,11 @@
 {% ckan_extends %}
 
 {% block footer_content %}
-    {% snippet 'home/snippets/footer_background.html' %}
+    {% if not g.userobj %}
+        {% snippet 'home/snippets/footer_background.html', loggedin="notloggedin" %}
+    {% else %}
+        {% snippet 'home/snippets/footer_background.html', loggedin="loggedin" %}
+    {% endif %}
     
     <div class="row footer-search-section">
         <div class="col-lg-6 col-sm-9 col-xs-12">

--- a/ckanext/who_afro/templates/home/snippets/footer_background.html
+++ b/ckanext/who_afro/templates/home/snippets/footer_background.html
@@ -1,3 +1,3 @@
 <div class="d-none d-md-block">
-    <div class="footer-bg bottom-right"></div>
+    <div class="footer-bg bottom-right {{ loggedin }}"></div>
 </div>

--- a/ckanext/who_afro/templates/snippets/subscribe_to_updates.html
+++ b/ckanext/who_afro/templates/snippets/subscribe_to_updates.html
@@ -13,4 +13,6 @@
         </div>
     </div>
 </div>
+{% else %}
+<div class="empty-subscribe"></div>
 {% endif %}


### PR DESCRIPTION
## Description

This PR, corresponding to ticket [WAC-115](https://fjelltopp.atlassian.net/browse/WAC-115) fixes the missing margin above the WHO logo and repositions the background image to be symmetrical about the x axis.

![WAC-115: Fix footer margins and reposition background image](https://github.com/user-attachments/assets/60f5066e-1777-4afa-8e35-b0ea16fa4b1b)

## Testing

This is a UI feature so only manual testing could be performed.
Please see the attached picture for acceptance testing.

## Checklist

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".


[WAC-115]: https://fjelltopp.atlassian.net/browse/WAC-115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ