### PR TITLE
feat: make the fallback font sans-serif for cleaner loading

### DIFF
--- a/ckanext/who_afro/assets/css/who-afro.css
+++ b/ckanext/who_afro/assets/css/who-afro.css
@@ -205,7 +205,7 @@ a.thumbnail.active {
 
 body {
     background: #fff;
-    font-family: 'Source Sans 3 VF', serif;
+    font-family: 'Source Sans 3 VF', sans-serif;
     font-style: normal;
     font-weight: 400;
     font-size: 16px;
@@ -3558,5 +3558,3 @@ ul.icon-list li .views-field-field-icon img {
     text-align: center;
     white-space: nowrap;
 }
-
-


### PR DESCRIPTION
## Description

It was annoying me that on slow internet the page would load with Serif fonts and then switch to Source Sans when the font was downloaded. This fallbacks to sans-serif so should be less obvious.

## Checklist

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
