### PR TITLE
WAC-119: Indicator list page redesign.

### DIFF
--- a/ckanext/who_afro/assets/css/who-afro.css
+++ b/ckanext/who_afro/assets/css/who-afro.css
@@ -2223,12 +2223,6 @@ div.main.search .wrapper > aside.secondary > .filters #field-order-by {
     background-position: right 1.25rem center;
 }
 
-div.main.search .wrapper > aside.secondary > .indicators-filters .tags,
-div.main.search .wrapper > aside.secondary > .indicators-filters .res_format,
-div.main.search .wrapper > aside.secondary > .indicators-filters .organization {
-    display: none;
-}
-
 div.main.search .wrapper > aside.secondary section.module {
     background-color: white;
     border-radius: 4px;

--- a/ckanext/who_afro/assets/css/who-afro.css
+++ b/ckanext/who_afro/assets/css/who-afro.css
@@ -3567,3 +3567,11 @@ ul.icon-list li .views-field-field-icon img {
     text-align: center;
     white-space: nowrap;
 }
+
+
+.main.indicators .secondary .module-narrow.res_format,
+.main.indicators .secondary .module-narrow.organization,
+.main.indicators .secondary .module-narrow.tags
+{
+    display: none;
+}

--- a/ckanext/who_afro/assets/css/who-afro.css
+++ b/ckanext/who_afro/assets/css/who-afro.css
@@ -2223,6 +2223,12 @@ div.main.search .wrapper > aside.secondary > .filters #field-order-by {
     background-position: right 1.25rem center;
 }
 
+div.main.search .wrapper > aside.secondary > .indicators-filters .tags,
+div.main.search .wrapper > aside.secondary > .indicators-filters .res_format,
+div.main.search .wrapper > aside.secondary > .indicators-filters .organization {
+    display: none;
+}
+
 div.main.search .wrapper > aside.secondary section.module {
     background-color: white;
     border-radius: 4px;

--- a/ckanext/who_afro/helpers.py
+++ b/ckanext/who_afro/helpers.py
@@ -209,10 +209,14 @@ def dataset_has_overview(pkg_dict):
 def get_indicator_name(resource_id):
     try:
         datastore_info = toolkit.get_action('datastore_info')({}, {'id': resource_id})
-        for field in datastore_info.get('fields', []):
-            if field['id'].endswith('_N') and field['type'] == 'numeric':
-                indicator_field = field['id']
-                break
     except toolkit.ObjectNotFound:
         return "Nothing found in the datastore for this indicator."
+    
+    for field in datastore_info.get('fields', []):
+        if field['id'].endswith('_N') and field['type'] == 'numeric':
+            indicator_field = field['id']
+            break
+    else:
+        return "No indicator value found within the dataset"
+
     return indicator_field

--- a/ckanext/who_afro/templates/group/read.html
+++ b/ckanext/who_afro/templates/group/read.html
@@ -2,7 +2,7 @@
 
 {% set placeholder = _('E.g. mortality') %}
 
-{% block maintag %}<div class="main search">{% endblock %}
+{% block maintag %}<div class="main {{group_dict.name}} search">{% endblock %}
 
 {% block promoted_toolbar %}
 <div class="promoted-background">

--- a/ckanext/who_afro/templates/group/read.html
+++ b/ckanext/who_afro/templates/group/read.html
@@ -47,7 +47,7 @@
 {% block secondary_content %}
   {% set sorting = [(_('Relevance'), 'score desc, metadata_modified desc'), (_('Name Ascending'), 'name asc'), (_('Name Descending'), 'name desc')] %}
   {% set sorting_selected = request.args.get('sort') %}
-  <div class="filters">
+  <div class="filters indicators-filters">
     <div>
       <h3>{{ _('Order by:') }}</h3>
       <div class="form-group control-order-by">

--- a/ckanext/who_afro/templates/group/read.html
+++ b/ckanext/who_afro/templates/group/read.html
@@ -1,14 +1,91 @@
 {% ckan_extends %}
 
+{% set placeholder = _('E.g. mortality') %}
+
+{% block maintag %}<div class="main search">{% endblock %}
+
+{% block promoted_toolbar %}
+<div class="promoted-background">
+    {% snippet 'package/snippets/promoted_plus.html' %}
+    <div class="container">
+        <div class="promoted">
+            <div class="promoted-container container">
+                <p class="subtitle">{{ _('Home') }} / </p>
+                <h1 class="headline">{{ group_dict.title }}</h1>
+                <p>{{ h.markdown_extract(group_dict.description, 180) }}</p>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block pre_primary %}
+  <div class="big-search-form">
+    {% set placeholder = placeholder if placeholder else _('Search datasets...') %}
+    {% set sorting = sorting if sorting else [(_('Name Ascending'), 'name asc'), (_('Name Descending'), 'name desc')] %}
+    {% set search_class = search_class if search_class else 'search-giant' %}
+    {% set no_bottom_border = no_bottom_border if no_bottom_border else false %}
+    {% set form_id = form_id if form_id else false %}
+
+    <h2> {{ _('Search data') }}</h2>
+
+    <form {% if form_id %}id="{{ form_id }}" {% endif %}class="search-form{% if no_bottom_border %} no-bottom-border{% endif %}"  method="get" action="{% url_for 'dataset.search' %}">
+        <div class="input-group">
+          <input aria-label="{% block header_site_search_label %}{{ placeholder }}{% endblock %}" id="field-giant-search" type="text" class="form-control input-lg" name="q" value="{{ query }}" autocomplete="off" placeholder="{{ placeholder }}">
+
+          <span class="input-group-btn">
+            <button class="btn btn-default btn-lg lens-btn" type="submit" value="search" aria-label="{{_('Submit')}}">
+                <i class="fa fa-search"></i><span class="search-label">{{ _('Search') }}</span>
+            </button>
+          </span>
+        </div>
+    </form>
+  </div>
+{% endblock %}
+
+
 {% block secondary_content %}
-  {% snippet "group/snippets/info.html", group=group_dict, show_nums=true %}
+  {% set sorting = [(_('Relevance'), 'score desc, metadata_modified desc'), (_('Name Ascending'), 'name asc'), (_('Name Descending'), 'name desc')] %}
+  {% set sorting_selected = request.args.get('sort') %}
   <div class="filters">
     <div>
-      {% for facet in facet_titles %}
-        {% set scheming_choices=h.scheming_field_by_name(h.scheming_get_dataset_schema(dataset_type).dataset_fields, facet).choices %}
-        {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet, search_facets=search_facets, scheming_choices=scheming_choices) }}
-      {% endfor %}
+      <h3>{{ _('Order by:') }}</h3>
+      <div class="form-group control-order-by">
+        <!-- <label for="field-order-by">{{ _('Order by') }}</label> -->
+        <select id="field-order-by" name="sort" class="form-control form-select" onchange="setSort(this.value);">
+          {% for label, value in sorting %}
+            {% if label and value %}
+              <option value="{{ value }}"{% if sorting_selected == value %} selected="selected"{% endif %}>{{ label }}</option>
+            {% endif %}
+          {% endfor %}
+        </select>
+        {% block search_sortby_button %}
+        <button class="btn btn-default js-hide" type="submit">{{ _('Go') }}</button>
+        {% endblock %}
+      </div>
+
+      <h3>{{ _('Filter by:') }}</h3>
+      <div class="accordion" id="filters">
+        {% for facet in facet_titles %}
+          {% set scheming_choices=h.scheming_field_by_name(h.scheming_get_dataset_schema(dataset_type).dataset_fields, facet).choices %}
+          {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet, search_facets=search_facets, scheming_choices=scheming_choices) }}
+        {% endfor %}
+      </div>
     </div>
     <a class="close no-text hide-filters"><i class="fa fa-times-circle"></i><span class="text">close</span></a>
   </div>
+  <script>
+    const url = new URL(window.location.href);
+    function setSort(sort_value) {
+      url.searchParams.set('sort', sort_value);
+      window.location.href = url;
+    }
+  </script>
+{% endblock %}
+
+{% block form %}
+  {% snippet 'snippets/search_form.html', type=dataset_type, query=q, count=page.item_count, error=query_error %}
+{% endblock %}
+
+{% block page_header %}
 {% endblock %}

--- a/ckanext/who_afro/templates/group/read.html
+++ b/ckanext/who_afro/templates/group/read.html
@@ -47,7 +47,7 @@
 {% block secondary_content %}
   {% set sorting = [(_('Relevance'), 'score desc, metadata_modified desc'), (_('Name Ascending'), 'name asc'), (_('Name Descending'), 'name desc')] %}
   {% set sorting_selected = request.args.get('sort') %}
-  <div class="filters indicators-filters">
+  <div class="filters">
     <div>
       <h3>{{ _('Order by:') }}</h3>
       <div class="form-group control-order-by">

--- a/ckanext/who_afro/templates/snippets/facet_list.html
+++ b/ckanext/who_afro/templates/snippets/facet_list.html
@@ -5,7 +5,7 @@
     {% with items = items or h.get_facet_items_dict(name, search_facets) %}
 	{% if items or not hide_empty %}
 	    {% block facet_list_item %}
-		<section class="module module-narrow module-shallow accordion-item">
+		<section class="module module-narrow module-shallow accordion-item {{ name }}">
 		    {% block facet_list_heading %}
 			<h2 class="module-heading accordion-header" id="{{ title }}-heading">
                 <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#{{ title }}-collapse" aria-expanded="true" aria-controls="{{ title }}-collapse">


### PR DESCRIPTION
## Description
This PR corresponding to ticket [WAC-119](https://fjelltopp.atlassian.net/browse/WAC-119) redesigns the indicator page according to [Lewis' design](https://www.figma.com/design/n83fVbFXBK01vONu6ApoBb/WHO-AFRO-Data-Hub?node-id=2439-1391&t=83mjEpk3Seaqzcev-0) while taking to have the same design applicable to the `sources` and `publications` pages.

This is the current outcome:
![WAC-119: Indicator page redesign](https://github.com/user-attachments/assets/9b1ed194-d4e9-440b-895d-1fc4452ed5b4)

## Testing
This is UI work so testing was done manually.
A proof of the outcome is attached in the picture above.

## Checklist
- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".


[WAC-119]: https://fjelltopp.atlassian.net/browse/WAC-119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ