### PR TITLE
WAC-119 Filter hiding

### DIFF
--- a/ckanext/who_afro/assets/css/who-afro.css
+++ b/ckanext/who_afro/assets/css/who-afro.css
@@ -3567,3 +3567,11 @@ ul.icon-list li .views-field-field-icon img {
     text-align: center;
     white-space: nowrap;
 }
+
+
+.main.indicators .secondary .module-narrow.res_format,
+.main.indicators .secondary .module-narrow.organization,
+.main.indicators .secondary .module-narrow.tags
+{
+    display: none;
+}

--- a/ckanext/who_afro/templates/group/read.html
+++ b/ckanext/who_afro/templates/group/read.html
@@ -2,7 +2,7 @@
 
 {% set placeholder = _('E.g. mortality') %}
 
-{% block maintag %}<div class="main search">{% endblock %}
+{% block maintag %}<div class="main {{group_dict.name}} search">{% endblock %}
 
 {% block promoted_toolbar %}
 <div class="promoted-background">

--- a/ckanext/who_afro/templates/snippets/facet_list.html
+++ b/ckanext/who_afro/templates/snippets/facet_list.html
@@ -5,7 +5,7 @@
     {% with items = items or h.get_facet_items_dict(name, search_facets) %}
 	{% if items or not hide_empty %}
 	    {% block facet_list_item %}
-		<section class="module module-narrow module-shallow accordion-item">
+		<section class="module module-narrow module-shallow accordion-item {{name}}">
 		    {% block facet_list_heading %}
 			<h2 class="module-heading accordion-header" id="{{ title }}-heading">
                 <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#{{ title }}-collapse" aria-expanded="true" aria-controls="{{ title }}-collapse">


### PR DESCRIPTION
## Description

My suggestion for hiding unwanted filters on specific group read pages using CSS. 

The benefit of this solution is that it is easy to modify on a "group by group" basis.

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".
