### PR TITLE
WAC-132: Added the about page link to the footer.

### DIFF
--- a/ckanext/who_afro/templates/footer.html
+++ b/ckanext/who_afro/templates/footer.html
@@ -36,6 +36,7 @@
                 <div class="desc-large">
                     <ul class="list-unstyled">
                         {% block footer_links %}
+                            <li><a class="footer-link" href="{{ h.url_for('/about') }}">{{ _('About') }}</a></li>
                             <li><a class="footer-link" href="{{ h.url_for('/organization') }}">{{ _('Organizations') }}</a></li>
                             <li><a class="footer-link" href="{{ h.url_for('/user/login') }}">{{ _('Account login') }}</a></li>
                             <li><a class="footer-link" href="{{ h.url_for('/terms/') }}" target="_blank">{{ _('Terms and conditions') }}</a><br />


### PR DESCRIPTION
## Description

The about page link was supposed to be moved from the header navigation menu to the footer navigation menu.
This PR, covered by ticket [WAC-132](https://fjelltopp.atlassian.net/browse/WAC-132) makes that happen.

Here is the finalized footer:
![Screenshot from 2024-08-20 02-57-34](https://github.com/user-attachments/assets/e438ccb8-21a5-46cb-8343-2c4ba77d8beb)

## Checklist

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".


[WAC-132]: https://fjelltopp.atlassian.net/browse/WAC-132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ