### PR TITLE
WAC-133: Make sure the 'account login' link in footer is not visible if a user is logged in

### DIFF
--- a/ckanext/who_afro/templates/footer.html
+++ b/ckanext/who_afro/templates/footer.html
@@ -37,7 +37,9 @@
                     <ul class="list-unstyled">
                         {% block footer_links %}
                             <li><a class="footer-link" href="{{ h.url_for('/organization') }}">{{ _('Organizations') }}</a></li>
-                            <li><a class="footer-link" href="{{ h.url_for('/user/login') }}">{{ _('Account login') }}</a></li>
+                            {% if not g.userobj %}
+                                <li><a class="footer-link" href="{{ h.url_for('/user/login') }}">{{ _('Account login') }}</a></li>
+                            {% endif %}
                             <li><a class="footer-link" href="{{ h.url_for('/terms/') }}" target="_blank">{{ _('Terms and conditions') }}</a><br />
                             <li><a class="footer-link" href="http://docs.ckan.org/en/2.10/api/" target="_blank">{{ _('API Docs') }}</a></li>
                             <li>


### PR DESCRIPTION
## Description

Previously, even if a user is logged in, an "account login" link would be shown at the bottom.
This PR, corresponding to ticket [WAC-133](https://fjelltopp.atlassian.net/browse/WAC-133) makes sure said link is only visible if no user is logged in.

This is the outcome when a user is logged in:
![WAC-133: Make sure account login link not visible if logged in](https://github.com/user-attachments/assets/c8d35a78-e089-4e19-b0d2-83bc392f58df)

And this is the outcome if a user is *not* logged in:
![WAC-133: Make sure account login link visible if not logged in](https://github.com/user-attachments/assets/073c023d-f2d0-469f-b371-75e4a18565fa)

## Checklist

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".


[WAC-133]: https://fjelltopp.atlassian.net/browse/WAC-133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ