### PR TITLE
WAC-134: Review the order by field on datasets and indicators

### DIFF
--- a/ckanext/who_afro/templates/group/read.html
+++ b/ckanext/who_afro/templates/group/read.html
@@ -22,8 +22,6 @@
 {% block pre_primary %}
   <div class="big-search-form">
     {% set placeholder = placeholder if placeholder else _('Search datasets...') %}
-    {% set sorting = sorting if sorting else [(_('Name Ascending'), 'name asc'), (_('Name Descending'), 'name desc')] %}
-    {% set search_class = search_class if search_class else 'search-giant' %}
     {% set no_bottom_border = no_bottom_border if no_bottom_border else false %}
     {% set form_id = form_id if form_id else false %}
 
@@ -45,7 +43,13 @@
 
 
 {% block secondary_content %}
-  {% set sorting = [(_('Relevance'), 'score desc, metadata_modified desc'), (_('Name Ascending'), 'name asc'), (_('Name Descending'), 'name desc')] %}
+  {% set sorting = [
+    (_('Relevance'), 'score desc, metadata_modified desc'),
+    (_('Name Ascending'), 'title_string asc'),
+    (_('Name Descending'), 'title_string desc'),
+    (_('Last Modified'), 'metadata_modified desc'),
+    (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
+  %}
   {% set sorting_selected = request.args.get('sort') %}
   <div class="filters">
     <div>

--- a/ckanext/who_afro/templates/group/read.html
+++ b/ckanext/who_afro/templates/group/read.html
@@ -55,7 +55,6 @@
     <div>
       <h3>{{ _('Order by:') }}</h3>
       <div class="form-group control-order-by">
-        <!-- <label for="field-order-by">{{ _('Order by') }}</label> -->
         <select id="field-order-by" name="sort" class="form-control form-select" onchange="setSort(this.value);">
           {% for label, value in sorting %}
             {% if label and value %}

--- a/ckanext/who_afro/templates/package/search.html
+++ b/ckanext/who_afro/templates/package/search.html
@@ -66,7 +66,6 @@
     <div>
       <h3>{{ _('Really by:') }}</h3>
       <div class="form-group control-order-by">
-        <!-- <label for="field-order-by">{{ _('Order by') }}</label> -->
         <select id="field-order-by" name="sort" class="form-control form-select" onchange="setSort(this.value);">
           {% for label, value in sorting %}
             {% if label and value %}

--- a/ckanext/who_afro/templates/package/search.html
+++ b/ckanext/who_afro/templates/package/search.html
@@ -33,8 +33,6 @@
 {% block pre_primary %}
   <div class="big-search-form">
     {% set placeholder = placeholder if placeholder else _('Search datasets...') %}
-    {% set sorting = sorting if sorting else [(_('Name Ascending'), 'name asc'), (_('Name Descending'), 'name desc')] %}
-    {% set search_class = search_class if search_class else 'search-giant' %}
     {% set no_bottom_border = no_bottom_border if no_bottom_border else false %}
     {% set form_id = form_id if form_id else false %}
 
@@ -56,11 +54,17 @@
 
 
 {% block secondary_content %}
-  {% set sorting = [(_('Relevance'), 'score desc, metadata_modified desc'), (_('Name Ascending'), 'name asc'), (_('Name Descending'), 'name desc')] %}
+  {% set sorting = [
+    (_('Relevance'), 'score desc, metadata_modified desc'),
+    (_('Name Ascending'), 'title_string asc'),
+    (_('Name Descending'), 'title_string desc'),
+    (_('Last Modified'), 'metadata_modified desc'),
+    (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
+  %}
   {% set sorting_selected = request.args.get('sort') %}
   <div class="filters">
     <div>
-      <h3>{{ _('Order by:') }}</h3>
+      <h3>{{ _('Really by:') }}</h3>
       <div class="form-group control-order-by">
         <!-- <label for="field-order-by">{{ _('Order by') }}</label> -->
         <select id="field-order-by" name="sort" class="form-control form-select" onchange="setSort(this.value);">


### PR DESCRIPTION
## Description

Previously, the order by field in the dataset and indicators list pages contained only the possibility to order by
relevance, name ascending and name descending.
This PR, corresponding to ticket [WAC-134](https://fjelltopp.atlassian.net/browse/WAC-134), adds the possibility to order by
last modified in the UI. In the code, the possibility to order by popularity is present as a placeholder to eventually replace it
with something like ordering by most downloaded.

Here is the outcome on the indicators list page (which is similar in this regard with the datasets page):
[Screencast from 08-20-2024 03:44:49 AM.webm](https://github.com/user-attachments/assets/e851d972-8ce2-4eff-a892-da31d0592d2e)

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] I have assigned at least one label to this PR: "patch", "minor", "major".


[WAC-134]: https://fjelltopp.atlassian.net/browse/WAC-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ