### PR TITLE
feat: make dashboard work with non-facetted indicators

### DIFF
--- a/ckanext/who_afro/helpers.py
+++ b/ckanext/who_afro/helpers.py
@@ -223,6 +223,8 @@ def get_indicator_details(resource_id):
     if not value_field:
         log.warning("No indicator value found for resource %s" % resource_id)
 
+    facet_field = ""
+    facet_label = ""
     for field in datastore_info.get('fields', []):
         if field['id'].endswith('DIM_SEX') and field['type'] == 'text':
             facet_field = "DIM_SEX"

--- a/ckanext/who_afro/helpers.py
+++ b/ckanext/who_afro/helpers.py
@@ -1,7 +1,10 @@
+import logging
 import ckan.model as model
 from ckan.common import c, request, is_flask_request, g
 from datetime import datetime, timedelta
 from ckan.plugins import toolkit
+
+log = logging.getLogger(__name__)
 
 
 def get_user_obj(field=""):
@@ -206,17 +209,31 @@ def dataset_has_overview(pkg_dict):
     return pkg_dict.get('type', '') in ['indicator']
 
 
-def get_indicator_name(resource_id):
+def get_indicator_details(resource_id):
+    datastore_info = {}
     try:
         datastore_info = toolkit.get_action('datastore_info')({}, {'id': resource_id})
     except toolkit.ObjectNotFound:
-        return "Nothing found in the datastore for this indicator."
-    
+        log.warning("No datastore found for resource %s" % resource_id)
+
+    value_field = ""
     for field in datastore_info.get('fields', []):
         if field['id'].endswith('_N') and field['type'] == 'numeric':
-            indicator_field = field['id']
-            break
-    else:
-        return "No indicator value found within the dataset"
+            value_field = field['id']
+    if not value_field:
+        log.warning("No indicator value found for resource %s" % resource_id)
 
-    return indicator_field
+    for field in datastore_info.get('fields', []):
+        if field['id'].endswith('DIM_SEX') and field['type'] == 'text':
+            facet_field = "DIM_SEX"
+            facet_label = "Sex"
+    if not facet_field:
+        log.warning("No facet field found for resource %s" % resource_id)
+
+    return {
+        "facet_label": facet_label,
+        "facet_field": facet_field,
+        "value_field": value_field,
+        "geo_field": "GEO_NAME_SHORT",
+        "time_field": "DIM_TIME"
+    }

--- a/ckanext/who_afro/plugin.py
+++ b/ckanext/who_afro/plugin.py
@@ -47,7 +47,7 @@ class WHOAFROPlugin(plugins.SingletonPlugin, DefaultTranslation):
             'get_activity_stream_limit': who_afro_helpers.get_activity_stream_limit,
             'get_license': who_afro_helpers.get_license,
             'dataset_has_overview': who_afro_helpers.dataset_has_overview,
-            'get_indicator_name': who_afro_helpers.get_indicator_name,
+            'get_indicator_details': who_afro_helpers.get_indicator_details,
         }
 
     # IConfigurer

--- a/ckanext/who_afro/templates/package/overview.html
+++ b/ckanext/who_afro/templates/package/overview.html
@@ -15,9 +15,9 @@
          data-resource-id="{{ resource_id }}"
          data-resource-title="{{ pkg.title }}"
          data-round-to-decimal-places="2"
-         data-labels='{ "segment": "{{ indicator_details.facet_label }}", "amount": "{{ pkg.title }}", "noRowsWarning": "No data to display" }'
+         data-labels='{ "segment": "Sex", "amount": "{{ pkg.title }}", "noRowsWarning": "No data to display" }'
          data-sexes='[ { "id": "TOTAL", "label": "Total", "color": "#171B38" }, { "id": "FEMALE", "label": "Female", "color": "#009ADE" }, { "id": "MALE", "label": "Male", "color": "#80BC00" } ]'
-         data-api-fields='{ "value": "{{ indicator_details.value_field }}", "country": "GEO_NAME_SHORT", "segment": "{{ indicator_details.facet_field }}", "time_axis": "DIM_TIME" }'>
+         data-api-fields='{ "value": "{{ indicator_details.value_field }}", "country": "GEO_NAME_SHORT", "segment": "DIM_SEX", "time_axis": "DIM_TIME" }'>
     </div>
     {% set url = h.url_for(pkg.type ~ '_resource.read', id=pkg.name, resource_id=resource_id) %}
     <div class="overview-data-link small">

--- a/ckanext/who_afro/templates/package/overview.html
+++ b/ckanext/who_afro/templates/package/overview.html
@@ -5,9 +5,9 @@
     {% set resource_id = pkg.resources[0].id %}
     {% set indicator_details = h.get_indicator_details(resource_id) %}
     {% if disaggregation_field=="DIM_SEX" %}
-        {% set facet = "[ { "id": "TOTAL", "label": "Total", "color": "#171B38" }, { "id": "FEMALE", "label": "Female", "color": "#009ADE" }, { "id": "MALE", "label": "Male", "color": "#80BC00" } ]" %}
+        {% set facet = '[ { "id": "TOTAL", "label": "Total", "color": "#171B38" }, { "id": "FEMALE", "label": "Female", "color": "#009ADE" }, { "id": "MALE", "label": "Male", "color": "#80BC00" } ]' %}
     {% else %}
-        {% set facet = "[ { "id": "TOTAL", "label": "Total", "color": "#171B38" } ]" %}
+        {% set facet = '[ { "id": "TOTAL", "label": "Total", "color": "#171B38" } ]' %}
     {% endif %}
     <div id="who-afro-js"
          data-datastore-path="{{ h.url_for('api.action', ver=3, logic_function='datastore_search') }}"

--- a/ckanext/who_afro/templates/package/overview.html
+++ b/ckanext/who_afro/templates/package/overview.html
@@ -1,25 +1,29 @@
-{% extends 'package/read_base.html' %}
+{% extends "package/read_base.html" %}
 
 {% block primary_content %}
     {% asset 'who-afro/who-afro-dashboard-css' %}
     {% set resource_id = pkg.resources[0].id %}
-    {% set indicator_field = h.get_indicator_name(resource_id) %}
+    {% set indicator_details = h.get_indicator_details(resource_id) %}
+    {% if disaggregation_field=="DIM_SEX" %}
+        {% set facet = "[ { "id": "TOTAL", "label": "Total", "color": "#171B38" }, { "id": "FEMALE", "label": "Female", "color": "#009ADE" }, { "id": "MALE", "label": "Male", "color": "#80BC00" } ]" %}
+    {% else %}
+        {% set facet = "[ { "id": "TOTAL", "label": "Total", "color": "#171B38" } ]" %}
     <div id="who-afro-js"
-         data-datastore-path="{{h.url_for('api.action', ver=3, logic_function='datastore_search')}}"
+         data-datastore-path="{{ h.url_for('api.action', ver=3, logic_function='datastore_search') }}"
          data-resource-id="{{ resource_id }}"
          data-resource-title="{{ pkg.title }}"
          data-round-to-decimal-places="2"
-         data-labels='{ "segment": "Sex", "amount": "{{ pkg.title }}", "noRowsWarning": "No data to display" }'
-         data-sexes='[ { "id": "TOTAL", "label": "Total", "color": "#171B38" }, { "id": "FEMALE", "label": "Female", "color": "#009ADE" }, { "id": "MALE", "label": "Male", "color": "#80BC00" } ]'
-         data-api-fields='{ "value": "{{ indicator_field }}", "country": "GEO_NAME_SHORT", "segment": "DIM_SEX", "time_axis": "DIM_TIME" }'>
+         data-labels='{ "segment": "{{ indicator_details.facet_label }}", "amount": "{{ pkg.title }}", "noRowsWarning": "No data to display" }'
+         data-sexes='{{ facet }}'
+         data-api-fields='{ "value": "{{ indicator_details.value_field }}", "country": "{{ indicator_details.geo_field }}", "segment": {{ disaggregation_field }}, "time_axis": "{{ indicator_details.time_field }}" }'>
     </div>
     {% set url = h.url_for(pkg.type ~ '_resource.read', id=pkg.name, resource_id=resource_id) %}
     <div class="overview-data-link small">
         <a target="_blank"
-           href="{{url}}">
-          {{_('Preview / Download Dataset')}}
+           href="{{ url }}">
+          {{ _('Preview / Download Dataset') }}
         </a>
     </div>
     {% asset 'who-afro/who-afro-dashboard-js' %}
     {%- snippet "scheming/package/snippets/access_use.html", pkg_dict=pkg_dict -%}
-{% endblock %}
+{% endblock primary_content %}

--- a/ckanext/who_afro/templates/package/overview.html
+++ b/ckanext/who_afro/templates/package/overview.html
@@ -8,6 +8,7 @@
         {% set facet = "[ { "id": "TOTAL", "label": "Total", "color": "#171B38" }, { "id": "FEMALE", "label": "Female", "color": "#009ADE" }, { "id": "MALE", "label": "Male", "color": "#80BC00" } ]" %}
     {% else %}
         {% set facet = "[ { "id": "TOTAL", "label": "Total", "color": "#171B38" } ]" %}
+    {% endif %}
     <div id="who-afro-js"
          data-datastore-path="{{ h.url_for('api.action', ver=3, logic_function='datastore_search') }}"
          data-resource-id="{{ resource_id }}"

--- a/ckanext/who_afro/templates/package/overview.html
+++ b/ckanext/who_afro/templates/package/overview.html
@@ -9,6 +9,7 @@
     {% else %}
         {% set facet = '[ { "id": "TOTAL", "label": "Total", "color": "#171B38" } ]' %}
     {% endif %}
+    <p>{{ indicator_details }}</p>
     <div id="who-afro-js"
          data-datastore-path="{{ h.url_for('api.action', ver=3, logic_function='datastore_search') }}"
          data-resource-id="{{ resource_id }}"

--- a/ckanext/who_afro/templates/package/overview.html
+++ b/ckanext/who_afro/templates/package/overview.html
@@ -17,7 +17,7 @@
          data-round-to-decimal-places="2"
          data-labels='{ "segment": "{{ indicator_details.facet_label }}", "amount": "{{ pkg.title }}", "noRowsWarning": "No data to display" }'
          data-sexes='{{ facet }}'
-         data-api-fields='{ "value": "{{ indicator_details.value_field }}", "country": "{{ indicator_details.geo_field }}", "segment": {{ indicator_details.facet_field }}, "time_axis": "{{ indicator_details.time_field }}" }'>
+         data-api-fields='{ "value": "{{ indicator_details.value_field }}", "country": "{{ indicator_details.geo_field }}", "segment": "{{ indicator_details.facet_field }}", "time_axis": "{{ indicator_details.time_field }}" }'>
     </div>
     {% set url = h.url_for(pkg.type ~ '_resource.read', id=pkg.name, resource_id=resource_id) %}
     <div class="overview-data-link small">

--- a/ckanext/who_afro/templates/package/overview.html
+++ b/ckanext/who_afro/templates/package/overview.html
@@ -4,20 +4,20 @@
     {% asset 'who-afro/who-afro-dashboard-css' %}
     {% set resource_id = pkg.resources[0].id %}
     {% set indicator_details = h.get_indicator_details(resource_id) %}
-    {# {% if indicator_details.facet_field=="DIM_SEX" %}
+    {% if indicator_details.facet_field=="DIM_SEX" %}
         {% set facet = '[ { "id": "TOTAL", "label": "Total", "color": "#171B38" }, { "id": "FEMALE", "label": "Female", "color": "#009ADE" }, { "id": "MALE", "label": "Male", "color": "#80BC00" } ]' %}
     {% else %}
         {% set facet = '[ { "id": "TOTAL", "label": "Total", "color": "#171B38" } ]' %}
-    {% endif %} #}
+    {% endif %}
     <p>{{ indicator_details }}</p>
     <div id="who-afro-js"
          data-datastore-path="{{ h.url_for('api.action', ver=3, logic_function='datastore_search') }}"
          data-resource-id="{{ resource_id }}"
          data-resource-title="{{ pkg.title }}"
          data-round-to-decimal-places="2"
-         data-labels='{ "segment": "Sex", "amount": "{{ pkg.title }}", "noRowsWarning": "No data to display" }'
-         data-sexes='[ { "id": "TOTAL", "label": "Total", "color": "#171B38" }, { "id": "FEMALE", "label": "Female", "color": "#009ADE" }, { "id": "MALE", "label": "Male", "color": "#80BC00" } ]'
-         data-api-fields='{ "value": "{{ indicator_details.value_field }}", "country": "GEO_NAME_SHORT", "segment": "DIM_SEX", "time_axis": "DIM_TIME" }'>
+         data-labels='{ "segment": "{{ indicator_details.facet_label }}", "amount": "{{ pkg.title }}", "noRowsWarning": "No data to display" }'
+         data-sexes='{{ facet }}'
+         data-api-fields='{ "value": "{{ indicator_details.value_field }}", "country": "{{ indicator_details.geo_field }}", "segment": "{{ indicator_details.facet_field }}", "time_axis": "{{ indicator_details.time_field }}" }'>
     </div>
     {% set url = h.url_for(pkg.type ~ '_resource.read', id=pkg.name, resource_id=resource_id) %}
     <div class="overview-data-link small">

--- a/ckanext/who_afro/templates/package/overview.html
+++ b/ckanext/who_afro/templates/package/overview.html
@@ -4,11 +4,11 @@
     {% asset 'who-afro/who-afro-dashboard-css' %}
     {% set resource_id = pkg.resources[0].id %}
     {% set indicator_details = h.get_indicator_details(resource_id) %}
-    {% if indicator_details.facet_field=="DIM_SEX" %}
+    {# {% if indicator_details.facet_field=="DIM_SEX" %}
         {% set facet = '[ { "id": "TOTAL", "label": "Total", "color": "#171B38" }, { "id": "FEMALE", "label": "Female", "color": "#009ADE" }, { "id": "MALE", "label": "Male", "color": "#80BC00" } ]' %}
     {% else %}
         {% set facet = '[ { "id": "TOTAL", "label": "Total", "color": "#171B38" } ]' %}
-    {% endif %}
+    {% endif %} #}
     <p>{{ indicator_details }}</p>
     <div id="who-afro-js"
          data-datastore-path="{{ h.url_for('api.action', ver=3, logic_function='datastore_search') }}"

--- a/ckanext/who_afro/templates/package/overview.html
+++ b/ckanext/who_afro/templates/package/overview.html
@@ -17,7 +17,7 @@
          data-round-to-decimal-places="2"
          data-labels='{ "segment": "{{ indicator_details.facet_label }}", "amount": "{{ pkg.title }}", "noRowsWarning": "No data to display" }'
          data-sexes='[ { "id": "TOTAL", "label": "Total", "color": "#171B38" }, { "id": "FEMALE", "label": "Female", "color": "#009ADE" }, { "id": "MALE", "label": "Male", "color": "#80BC00" } ]'
-         data-api-fields='{ "value": "{{ indicator_details.value_field }}", "country": "{{ indicator_details.geo_field }}", "segment": "{{ indicator_details.facet_field }}", "time_axis": "{{ indicator_details.time_field }}" }'>
+         data-api-fields='{ "value": "{{ indicator_details.value_field }}", "country": "GEO_NAME_SHORT", "segment": "{{ indicator_details.facet_field }}", "time_axis": "DIM_TIME" }'>
     </div>
     {% set url = h.url_for(pkg.type ~ '_resource.read', id=pkg.name, resource_id=resource_id) %}
     <div class="overview-data-link small">

--- a/ckanext/who_afro/templates/package/overview.html
+++ b/ckanext/who_afro/templates/package/overview.html
@@ -16,7 +16,7 @@
          data-resource-title="{{ pkg.title }}"
          data-round-to-decimal-places="2"
          data-labels='{ "segment": "{{ indicator_details.facet_label }}", "amount": "{{ pkg.title }}", "noRowsWarning": "No data to display" }'
-         data-sexes='{{ facet }}'
+         data-sexes='[ { "id": "TOTAL", "label": "Total", "color": "#171B38" }, { "id": "FEMALE", "label": "Female", "color": "#009ADE" }, { "id": "MALE", "label": "Male", "color": "#80BC00" } ]'
          data-api-fields='{ "value": "{{ indicator_details.value_field }}", "country": "{{ indicator_details.geo_field }}", "segment": "{{ indicator_details.facet_field }}", "time_axis": "{{ indicator_details.time_field }}" }'>
     </div>
     {% set url = h.url_for(pkg.type ~ '_resource.read', id=pkg.name, resource_id=resource_id) %}

--- a/ckanext/who_afro/templates/package/overview.html
+++ b/ckanext/who_afro/templates/package/overview.html
@@ -4,7 +4,7 @@
     {% asset 'who-afro/who-afro-dashboard-css' %}
     {% set resource_id = pkg.resources[0].id %}
     {% set indicator_details = h.get_indicator_details(resource_id) %}
-    {% if disaggregation_field=="DIM_SEX" %}
+    {% if indicator_details.facet_field=="DIM_SEX" %}
         {% set facet = '[ { "id": "TOTAL", "label": "Total", "color": "#171B38" }, { "id": "FEMALE", "label": "Female", "color": "#009ADE" }, { "id": "MALE", "label": "Male", "color": "#80BC00" } ]' %}
     {% else %}
         {% set facet = '[ { "id": "TOTAL", "label": "Total", "color": "#171B38" } ]' %}
@@ -16,7 +16,7 @@
          data-round-to-decimal-places="2"
          data-labels='{ "segment": "{{ indicator_details.facet_label }}", "amount": "{{ pkg.title }}", "noRowsWarning": "No data to display" }'
          data-sexes='{{ facet }}'
-         data-api-fields='{ "value": "{{ indicator_details.value_field }}", "country": "{{ indicator_details.geo_field }}", "segment": {{ disaggregation_field }}, "time_axis": "{{ indicator_details.time_field }}" }'>
+         data-api-fields='{ "value": "{{ indicator_details.value_field }}", "country": "{{ indicator_details.geo_field }}", "segment": {{ indicator_details.facet_field }}, "time_axis": "{{ indicator_details.time_field }}" }'>
     </div>
     {% set url = h.url_for(pkg.type ~ '_resource.read', id=pkg.name, resource_id=resource_id) %}
     <div class="overview-data-link small">


### PR DESCRIPTION
## Description

The client has provided two new indicators and they need no facetting, e.g. they do not have sex disaggregation.

This updates the dashboard to handle the situation where the DIM_SEX field does not exist.

It _should_ be backwards compatible (see Testing below).

## Testing

Tested live with @A-Souhei - I will manually check all current indicators when this is deployed.

## Checklist

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
