### PR TITLE
fix: make group search search groups

### DIFF
--- a/ckanext/who_afro/templates/group/read.html
+++ b/ckanext/who_afro/templates/group/read.html
@@ -27,7 +27,7 @@
 
     <h2> {{ _('Search data') }}</h2>
 
-    <form {% if form_id %}id="{{ form_id }}" {% endif %}class="search-form{% if no_bottom_border %} no-bottom-border{% endif %}"  method="get" action="{% url_for 'dataset.search' %}">
+    <form {% if form_id %}id="{{ form_id }}" {% endif %}class="search-form{% if no_bottom_border %} no-bottom-border{% endif %}"  method="get" data-module="select-switch">
         <div class="input-group">
           <input aria-label="{% block header_site_search_label %}{{ placeholder }}{% endblock %}" id="field-giant-search" type="text" class="form-control input-lg" name="q" value="{{ query }}" autocomplete="off" placeholder="{{ placeholder }}">
 


### PR DESCRIPTION
## Description

Hitting "Search" on the indicators page was actually doing a dataset search. This should fix that.

## Checklist

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
