### PR TITLE
WAC-139 Fix link color in indicator page hero and 

### DIFF
--- a/ckanext/who_afro/assets/css/who-afro.css
+++ b/ckanext/who_afro/assets/css/who-afro.css
@@ -3524,7 +3524,7 @@ ul.icon-list {
 }
 
 ul.icon-list li {
-    margin-bottom: 10px;
+    margin-bottom: 40px;
     min-height: 70px;
     display: flex;
     page-break-inside: avoid;

--- a/ckanext/who_afro/assets/css/who-afro.css
+++ b/ckanext/who_afro/assets/css/who-afro.css
@@ -581,12 +581,13 @@ div[role=main]{
     }
 }
 
-.promoted-home .promoted-container > .description > p > a {
-    color: white;
-}
 .promoted .container {
     padding-top: 64px;
     padding-bottom: 64px;
+}
+
+.promoted .container > .description > p > a {
+    color: white;
 }
 
 .promoted-left {

--- a/ckanext/who_afro/assets/css/who-afro.css
+++ b/ckanext/who_afro/assets/css/who-afro.css
@@ -3484,7 +3484,7 @@ div.main.countries {
     }
 
     .masthead .main-navbar ul li.active a {
-        padding-bottom: 47px !important;
+        padding-bottom: 43px !important;
         border-bottom: var(--secondary-who-blue) 4px solid;
         border-radius: 0;
         z-index: 0;

--- a/ckanext/who_afro/assets/css/who-afro.css
+++ b/ckanext/who_afro/assets/css/who-afro.css
@@ -581,6 +581,9 @@ div[role=main]{
     }
 }
 
+.promoted-home .promoted-container > .description > p > a {
+    color: white;
+}
 .promoted .container {
     padding-top: 64px;
     padding-bottom: 64px;


### PR DESCRIPTION
## Description

This PR, corresponding to the ticket [WAC](), takes care of the following:
- Make sure links in the hero are not of a navy blue color but white,
- Brings back the blue border below the active menu,
- Increases the vertical margin between countries.

This is how links look in the hero now:
![WAC-139: make link white in hero](https://github.com/user-attachments/assets/5d3138d6-8233-4c1f-923b-1f7bd735d20b)

This is how the active menu and countries look now:
![WAC-139: put back active menu item border bottom](https://github.com/user-attachments/assets/4f34dbe9-2003-4502-80bd-31ae809e03f6)


## Checklist

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
