### PR TITLE
Fix search bar focus and typographical error in datasets page.

### DIFF
--- a/ckanext/who_afro/assets/css/who-afro.css
+++ b/ckanext/who_afro/assets/css/who-afro.css
@@ -2214,6 +2214,7 @@ div.main.countries .wrapper{
 
 div.main.search .wrapper::before {
     border: none;
+    z-index: 0;
 }
 
 div.main.search .row > .big-search-form {

--- a/ckanext/who_afro/templates/package/search.html
+++ b/ckanext/who_afro/templates/package/search.html
@@ -64,7 +64,7 @@
   {% set sorting_selected = request.args.get('sort') %}
   <div class="filters">
     <div>
-      <h3>{{ _('Really by:') }}</h3>
+      <h3>{{ _('Order by:') }}</h3>
       <div class="form-group control-order-by">
         <select id="field-order-by" name="sort" class="form-control form-select" onchange="setSort(this.value);">
           {% for label, value in sorting %}


### PR DESCRIPTION
## Description

This PR fixes two UI issues:
- The search bar was not entirely focusable which can be frustrating to users who may think the field is disabled.
- The title for the "Order by" field was "Really by".

The issues can be found in the "Data" page (and the "Indicators" page for search) as can be seen in the attached picture.

![Screenshot from 2024-10-04 11-58-25](https://github.com/user-attachments/assets/d905e550-be7e-4da2-b5ff-7ad3a13ab15c)

## Checklist

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
