### PR TITLE
Get a package last modifier based on the package name instead of the package ID to avoid a ckan.logic.NotFound exception

### DIFF
--- a/ckanext/who_afro/templates/snippets/package_item.html
+++ b/ckanext/who_afro/templates/snippets/package_item.html
@@ -14,6 +14,6 @@
         <span class="badge {{ package.type }}">{{ _(package.type) }}</span>
     </h2>
     <div class="modified">
-        {{_('Modified')}} {{ h.time_ago_from_timestamp(package.metadata_modified) }}, {{ h.get_last_modifier(package.id) }} &middot; {{_('Downloads:')}} {{ h.get_package_stats(package.id) }}
+        {{_('Modified')}} {{ h.time_ago_from_timestamp(package.metadata_modified) }}, {{ h.get_last_modifier(package.name) }} &middot; {{_('Downloads:')}} {{ h.get_package_stats(package.id) }}
     </div>
 {% endblock %}


### PR DESCRIPTION
## Description
Running pipelines in `who-afro-dags` resulted in certain packages not being found by their IDs even though they clearly exist.
This PR changes the way we get a package last activity where we rely on the package name instead of the package ID which fixes the afore mentioned issue.

## Testing
This PR was tested manually instead of making an automated test as I still do not know how to reliably reproduce the issue
that resulted in this work.

## Checklist
- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
