### PR TITLE
feat: add error handling blueprint and under construction page

### DIFF
--- a/ckanext/who_afro/blueprints/__init__.py
+++ b/ckanext/who_afro/blueprints/__init__.py
@@ -1,8 +1,9 @@
-import ckanext.who_afro.blueprints.insights as insights
 import ckanext.who_afro.blueprints.countries as countries
-import ckanext.who_afro.blueprints.terms as terms
-import ckanext.who_afro.blueprints.sources as sources
+import ckanext.who_afro.blueprints.errors as errors
+import ckanext.who_afro.blueprints.insights as insights
 import ckanext.who_afro.blueprints.overview as overview
+import ckanext.who_afro.blueprints.sources as sources
+import ckanext.who_afro.blueprints.terms as terms
 
 
 def get_blueprints():
@@ -11,5 +12,6 @@ def get_blueprints():
         countries.blueprint,
         terms.blueprint,
         sources.blueprint,
-        overview.blueprint
+        overview.blueprint,
+        errors.blueprint,
     ]

--- a/ckanext/who_afro/blueprints/errors.py
+++ b/ckanext/who_afro/blueprints/errors.py
@@ -1,0 +1,14 @@
+import logging
+
+from flask import Blueprint, render_template
+
+log = logging.getLogger(__name__)
+
+blueprint = Blueprint(
+    "errors", __name__, url_prefix="/errors"
+)
+
+
+@blueprint.get("/", endpoint="under-construction")
+def under_construction():
+    return render_template("under-construction.html")

--- a/ckanext/who_afro/blueprints/insights.py
+++ b/ckanext/who_afro/blueprints/insights.py
@@ -1,5 +1,6 @@
 import logging
 
+import ckan.plugins.toolkit as tk
 from flask import Blueprint, render_template
 
 log = logging.getLogger(__name__)
@@ -11,4 +12,5 @@ blueprint = Blueprint(
 
 @blueprint.get("/", endpoint="index")
 def featured_insights():
-    return render_template("insights/featured.html")
+    return tk.redirect_to("errors.under-construction")
+    # return render_template("insights/featured.html")

--- a/ckanext/who_afro/templates/header.html
+++ b/ckanext/who_afro/templates/header.html
@@ -33,7 +33,7 @@
     {{ h.build_nav('countries.index', _('Countries'))}}
     {{ h.build_nav('group.read', _('Indicators'), id='indicators', highlight_controllers="groupv")}}
     {{ h.build_nav('sources.index', _('Sources'))}}
-    {{ h.build_nav('dataset.search', _('Data'))}}
+    {{ h.build_nav('errors.under-construction', _('Data'))}}
     {{ h.build_nav('insights.index', _('Insights'))}}
 
     {% if c.userobj %}

--- a/ckanext/who_afro/templates/under-construction.html
+++ b/ckanext/who_afro/templates/under-construction.html
@@ -1,0 +1,19 @@
+{% extends "page.html" %}
+
+{% block subtitle %}{{ _('Under construction') }}{% endblock subtitle%}
+
+{% block content %}
+<div role="main" class="insights-page">
+    <div class="promoted-background ">
+        <div class="container">
+            <div class="promoted promoted-home col-xs-12 col-sm-10 col-md-8 col-lg-6">
+                <div class="promoted-container">
+                    <p class="subtitle">{{ _('Home') }} / </p>
+                    <h1 class="page-title">{{ _('Under construction') }}</h1>
+                    <p>{{ _('This page is currently under construction - please check back later.') }}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock content %}


### PR DESCRIPTION
## Description

The client has asked if the "Data" and "Insights" pages can be temporarily left as "under construction" holding pages as the hub is going to be linked to from the main WHO AFRO website.

Deployment was originally blocked due fjelltopp/ckanext-googleanalytics4#4

## Testing

Manually tested on local dev and staging

## Checklist

- [ ] The GitHub ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
