### PR TITLE
Search input now has the value of query parameter in dataset search page

### DIFF
--- a/ckanext/who_afro/templates/package/search.html
+++ b/ckanext/who_afro/templates/package/search.html
@@ -1,6 +1,7 @@
 {% ckan_extends %}
 
 {% set tags = h.get_facet_items_dict('tags', c.search_facets, limit=3) %}
+{% set query = request.args.get('q', '') %}
 {% set placeholder = _('E.g. environment') %}
 {% set stats = h.get_site_statistics() %}
 


### PR DESCRIPTION
## Description

The search parameter is now set as value of the search input

![image](https://github.com/user-attachments/assets/bd40c6ab-8e26-447f-a203-a56df04ab40c)

Closes https://github.com/fjelltopp/who-afro-ckan/issues/617


## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The GitHub ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] I have assigned at least one label to this PR: "patch", "minor", "major".
